### PR TITLE
Issue#14 pull request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,35 @@ cmake_minimum_required(VERSION 3.5)
 
 project(uvgrtp)
 
+include(CheckCXXCompilerFlag)
+include(CheckCXXSymbolExists)
+
+# Check for standard to use
+check_cxx_compiler_flag(-std=c++17 HAVE_FLAG_STD_CXX17)
+
+if(HAVE_FLAG_STD_CXX17)
+    # Have -std=c++17, use it
+    set(CXX_STANDARD c++17)
+else()
+    check_cxx_compiler_flag(-std=c++11 HAVE_FLAG_STD_CXX11)
+
+    if(HAVE_FLAG_STD_CXX11)
+        # Have -std=c++11, use it
+        set(CXX_STANDARD c++11)
+    else()
+        # Abort
+        message( FATAL_ERROR "The compiler doen't support neither c++17 nor c++11. CMake will exit." )
+    endif()
+endif()
+
+# Check the getrandom() function exists
+check_cxx_symbol_exists(getrandom sys/random.h HAVE_GETRANDOM)
+
+if(HAVE_GETRANDOM)
+    add_compile_definitions(HAVE_GETRANDOM=1)
+endif()
+
+
 option(DISABLE_CRYPTO "Do not build uvgRTP with crypto enabled")
 option(PTHREADS_PATH  "Path to POSIX threads static library")
 option(CRYPTOPP_PATH  "Path to Crypto++ static library")
@@ -74,7 +103,7 @@ if (CRYPTOPP_PATH AND NOT DISABLE_CRYPTO)
 endif (CRYPTOPP_PATH AND NOT DISABLE_CRYPTO)
 
 if (UNIX)
-    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wuninitialized -Wshadow -O2 -g -std=c++17 -march=native -DNDEBUG")
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wuninitialized -Wshadow -O2 -g -std=${CXX_STANDARD} -march=native -DNDEBUG")
 
     if (DISABLE_CRYPTO)
         string(APPEND CMAKE_CXX_FLAGS " -D__RTP_NO_CRYPTO__")
@@ -104,9 +133,9 @@ endif (UNIX)
 
 if (WIN32)
     if(MSVC)
-        set(CMAKE_CXX_FLAGS "/O2 /std:c++17 /DNDEBUG")
+        set(CMAKE_CXX_FLAGS "/O2 /std:${CXX_STANDARD} /DNDEBUG")
     else(MSVC)
-        set(CMAKE_CXX_FLAGS "-O2 -std=c++17 -DNDEBUG")
+        set(CMAKE_CXX_FLAGS "-O2 -std=${CXX_STANDARD} -DNDEBUG")
     endif(MSVC)
     SET(OUT_DIR ${CMAKE_BINARY_DIR}/Debug)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,11 +106,10 @@ if (CRYPTOPP_PATH AND NOT DISABLE_CRYPTO)
 endif (CRYPTOPP_PATH AND NOT DISABLE_CRYPTO)
 
 if (UNIX)
-    add_definitions(-DNDEBUG)
-    add_compile_options(-Wall -Wextra -Wuninitialized -Wshadow -O2 -g -march=native)
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wuninitialized -Wshadow -O2 -g -std=${CXX_STANDARD} -march=native -DNDEBUG")
 
     if (DISABLE_CRYPTO)
-        add_definitions(-D__RTP_NO_CRYPTO__)
+        string(APPEND CMAKE_CXX_FLAGS " -D__RTP_NO_CRYPTO__")
     endif(DISABLE_CRYPTO)
 
     # if (NOT "${LIBRARY_PATHS}" STREQUAL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,3 +169,4 @@ if (WIN32)
             FILES_MATCHING PATTERN "*.hh"
     )
 endif (WIN32)
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # uvgRTP
 
-uvgRTP is an *Real-Time Transport Protocol (RTP)* library written in C++ with a focus on simple to use and high-efficiency media delivery over the internet. It features an intuitive and easy-to-use *Application Programming Interface (API)*, built-in support for transporting *Versitile Video Coding (VVC)*, *High Efficiency Video Coding (HEVC)*, *Advanced Video Coding (AVC)* encoded video and Opus encoded audio. uvgRTP also supports End-to-End Encrypted (E2EE) media delivery with *Secure RTP (SRTP)* and ZRTP. According to [our measurements](https://ieeexplore.ieee.org/abstract/document/9287162) uvgRTP is able to reach a goodput of 600 MB/s for HEVC stream when measured in LAN. The goodput value is dependant on CPU power.
+uvgRTP is an *Real-Time Transport Protocol (RTP)* library written in C++ with a focus on simple to use and high-efficiency media delivery over the internet. It features an intuitive and easy-to-use *Application Programming Interface (API)*, built-in support for transporting *Versitile Video Coding (VVC)*, *High Efficiency Video Coding (HEVC)*, *Advanced Video Coding (AVC)* encoded video and Opus encoded audio. uvgRTP also supports *End-to-End Encrypted (E2EE)* media delivery using the combination of *Secure RTP (SRTP)* and ZRTP. According to [our measurements](https://ieeexplore.ieee.org/abstract/document/9287162) uvgRTP is able to reach a goodput of 600 MB/s (4K at 700fps) for HEVC stream when measured in LAN. The CPU usage is relative to the goodput value, and therefore smaller streams have a very small CPU usage.
 
 uvgRTP is licensed under the permissive BSD 2-Clause License. For SRTP/ZRTP support, uvgRTP uses [Crypto++ library](https://www.cryptopp.com/). Currently uvgRTP is currently not under active development, but we will do our best to fix any issues and we warmly welcome any contributions to the project.
 
@@ -13,14 +13,14 @@ Currently supported specifications:
    * [RFC 6189: ZRTP: Media Path Key Agreement for Unicast Secure RTP](https://tools.ietf.org/html/rfc6189)
    * [Draft: RTP Payload Format for Versatile Video Coding (VVC)](https://tools.ietf.org/html/draft-ietf-avtcore-rtp-vvc-08)
 
-The original version of uvgRTP was based on Marko Viitanen's [fRTPlib library](https://github.com/fador/fRTPlib).
+The original version of uvgRTP is based on Marko Viitanen's [fRTPlib library](https://github.com/fador/fRTPlib).
 
 ## Notable features
 
 * Built-in support for:
     * AVC/HEVC/VVC video streaming
     * Opus audio streaming
-    * SRTP/ZRTP
+    * Delivery encryption with SRTP/ZRTP
 * Generic interface for custom media types
 * UDP hole punching
 * Simple to use API

--- a/include/crypto.hh
+++ b/include/crypto.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#if __cplusplus >= 201703L
 #if __has_include(<cryptopp/aes.h>) && \
     __has_include(<cryptopp/base32.h>) && \
     __has_include(<cryptopp/cryptlib.h>) && \
@@ -24,6 +25,22 @@
 #include <cryptopp/crc.h>
 
 #endif
+#else // __cplusplus
+#ifndef __RTP_NO_CRYPTO__
+#define __RTP_CRYPTO__
+
+#include <cryptopp/aes.h>
+#include <cryptopp/base32.h>
+#include <cryptopp/cryptlib.h>
+#include <cryptopp/dh.h>
+#include <cryptopp/hmac.h>
+#include <cryptopp/modes.h>
+#include <cryptopp/osrng.h>
+#include <cryptopp/sha.h>
+#include <cryptopp/crc.h>
+
+#endif
+#endif // __cplusplus
 
 namespace uvgrtp {
 

--- a/src/random.cc
+++ b/src/random.cc
@@ -2,9 +2,14 @@
 #include <winsock2.h>
 #include <windows.h>
 #include <wincrypt.h>
-#else
+#else // _WIN32
+#ifdef HAVE_GETRANDOM
 #include <sys/random.h>
-#endif
+#else // HAVE_GETRANDOM
+#include <unistd.h>
+#include <sys/syscall.h>
+#endif // HAVE_GETRANDOM
+#endif // _WIN32
 
 #include <cstdlib>
 #include <ctime>
@@ -25,8 +30,27 @@ rtp_error_t uvgrtp::random::init()
 int uvgrtp::random::generate(void *buf, size_t n)
 {
 #ifdef __linux__
+#ifdef HAVE_GETRANDOM
     return getrandom(buf, n, 0);
-#else
+#else // HAVE_GETRANDOM
+
+    // Replace with the syscall
+    int read = syscall(SYS_getrandom, buf, n, 0);
+
+    // On error, return the same value as getrandom()
+    if (read == -EINTR || read == -ERESTART) {
+        errno = EINTR;
+        read = -1;
+    }
+
+    if (read < -1) {
+        errno = -read;
+        read = -1;
+    }
+
+    return read;
+#endif // HAVE_GETRANDOM
+#else // __linux__
     HCRYPTPROV hCryptProv;
     if (CryptAcquireContext(&hCryptProv, NULL, NULL, PROV_RSA_FULL, 0) == TRUE) {
         bool res = CryptGenRandom(hCryptProv, n, (BYTE *)buf);
@@ -36,7 +60,7 @@ int uvgrtp::random::generate(void *buf, size_t n)
         return res ? 0 : -1;
     }
     return -1;
-#endif
+#endif // __linux__
 }
 
 uint32_t uvgrtp::random::generate_32()


### PR DESCRIPTION
I am using the uvgRTP 1.0.0 on a multimedia CentOS7 project. I would like to upgrade to the 2.0.0 version but it doesn't compile anymore, and the OS upgrade is not an option.

This pull request allows the compilation of uvgRTP on CentOS7 where c++17 and the getrandom() functions aren't available.

The CMakeLists.txt checks the c++ compiler standard conformance and adjusts the compilation directive -std accordingly.
It checks also the availability of the getrandom() function and creates the HAVE_GETRANDOM preprocessor definition if this function exists.

If the getrrandom() function doesn't exist, the equivalent syscall replaces it.

If the c++ compiler is a c++17 or higher one, and the getrandom() is available, the original code is left unchanged