### PR TITLE
build: Support for CentOS7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,14 @@ if (UNIX)
         string(APPEND COMPILER_FLAGS " -D__RTP_NO_CRYPTO__")
     endif(DISABLE_CRYPTO)
 
+    # Check the getrandom() function exists
+    include(CheckCXXSymbolExists)
+    check_cxx_symbol_exists(getrandom sys/random.h HAVE_GETRANDOM)
+
+    if(HAVE_GETRANDOM)
+        add_compile_definitions(HAVE_GETRANDOM=1)
+    endif()
+
     # if (NOT "${LIBRARY_PATHS}" STREQUAL "")
     #     add_custom_command(TARGET uvgrtp POST_BUILD
     #         COMMAND ar crsT ARGS libuvgrtp_thin.a libuvgrtp.a ${LIBRARY_PATHS}

--- a/include/crypto.hh
+++ b/include/crypto.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#if __cplusplus >= 201703L
 #if __has_include(<cryptopp/aes.h>) && \
     __has_include(<cryptopp/base32.h>) && \
     __has_include(<cryptopp/cryptlib.h>) && \
@@ -24,6 +25,22 @@
 #include <cryptopp/crc.h>
 
 #endif
+#else // __cplusplus
+#ifndef __RTP_NO_CRYPTO__
+#define __RTP_CRYPTO__
+
+#include <cryptopp/aes.h>
+#include <cryptopp/base32.h>
+#include <cryptopp/cryptlib.h>
+#include <cryptopp/dh.h>
+#include <cryptopp/hmac.h>
+#include <cryptopp/modes.h>
+#include <cryptopp/osrng.h>
+#include <cryptopp/sha.h>
+#include <cryptopp/crc.h>
+
+#endif
+#endif // __cplusplus
 
 namespace uvgrtp {
 


### PR DESCRIPTION
The 2.0.0 release of uvgRTP fails to build on CentOS7, because :
- the gcc-c++ compiler doesn't support the c++17 standard, which is
  required to compile the crypto.hh file
- the getrandom() function isn't available in the libc

This pull request adds CentOS7 build support.

The modified files are :

- CMakeLists.txt : the availability of the getrandom() function is checked.
  If it exists, the HAVE_GETRANDOM preprocessor definition is added

- src/random.cc : if HAVE_GETRANDOM isn't defined, a syscall equivalent to
  the getrandom() functions is called

- include/crypto.hh : the c++17 code is replaced by a code that compiles with
  the CentOS7 compiler (c++11)