### PR TITLE
common: #23 removed useless if statements for nullptr checks

### DIFF
--- a/src/dispatch.cc
+++ b/src/dispatch.cc
@@ -17,9 +17,7 @@ uvgrtp::dispatcher::~dispatcher()
 
 rtp_error_t uvgrtp::dispatcher::start()
 {
-    if ((runner_ = new std::thread(dispatch_runner, this, socket_)) == nullptr)
-        return RTP_MEMORY_ERROR;
-
+    runner_ = new std::thread(dispatch_runner, this, socket_);
     runner_->detach();
 
     return uvgrtp::runner::start();

--- a/src/formats/h265_pkt_handler.cc
+++ b/src/formats/h265_pkt_handler.cc
@@ -155,11 +155,6 @@ rtp_error_t uvgrtp::formats::h265::packet_handler(void *arg, int flags, uvgrtp::
         if (flags & RCE_H26X_PREPEND_SC) {
             uint8_t *pl = new uint8_t[(*out)->payload_len + 4];
 
-            if (!pl) {
-                LOG_ERROR("Failed to allocate space for a start code");
-                return RTP_GENERIC_ERROR;
-            }
-
             pl[0] = 0;
             pl[1] = 0;
             pl[2] = 0;
@@ -289,10 +284,7 @@ rtp_error_t uvgrtp::formats::h265::packet_handler(void *arg, int flags, uvgrtp::
                 + uvgrtp::frame::HEADER_SIZE_H265_NAL +
                 + ((flags & RCE_H26X_PREPEND_SC) ? 4 : 0);
 
-            if (!(complete->payload = new uint8_t[complete->payload_len])) {
-                LOG_ERROR("Failed to allocate memory for RTP frame");
-                return RTP_GENERIC_ERROR;
-            }
+            complete->payload = new uint8_t[complete->payload_len];
 
             if (flags & RCE_H26X_PREPEND_SC) {
                 complete->payload[0]  = 0;

--- a/src/formats/h266_pkt_handler.cc
+++ b/src/formats/h266_pkt_handler.cc
@@ -117,11 +117,6 @@ rtp_error_t uvgrtp::formats::h266::packet_handler(void *arg, int flags, uvgrtp::
         if (flags & RCE_H26X_PREPEND_SC) {
             uint8_t *pl = new uint8_t[(*out)->payload_len + 4];
 
-            if (!pl) {
-                LOG_ERROR("Failed to allocate space for a start code");
-                return RTP_GENERIC_ERROR;
-            }
-
             pl[0] = 0;
             pl[1] = 0;
             pl[2] = 0;
@@ -251,10 +246,7 @@ rtp_error_t uvgrtp::formats::h266::packet_handler(void *arg, int flags, uvgrtp::
                 + uvgrtp::frame::HEADER_SIZE_H266_NAL +
                 + ((flags & RCE_H26X_PREPEND_SC) ? 4 : 0);
 
-            if (!(complete->payload = new uint8_t[complete->payload_len])) {
-                LOG_ERROR("Failed to allocate memory for RTP frame");
-                return RTP_GENERIC_ERROR;
-            }
+           complete->payload = new uint8_t[complete->payload_len];
 
             if (flags & RCE_H26X_PREPEND_SC) {
                 complete->payload[0]  = 0;

--- a/src/frame.cc
+++ b/src/frame.cc
@@ -10,11 +10,6 @@ uvgrtp::frame::rtp_frame *uvgrtp::frame::alloc_rtp_frame()
 {
     uvgrtp::frame::rtp_frame *frame = new uvgrtp::frame::rtp_frame;
 
-    if (!frame) {
-        rtp_errno = RTP_MEMORY_ERROR;
-        return nullptr;
-    }
-
     std::memset(&frame->header, 0, sizeof(uvgrtp::frame::rtp_header));
     std::memset(frame,          0, sizeof(uvgrtp::frame::rtp_frame));
 

--- a/src/holepuncher.cc
+++ b/src/holepuncher.cc
@@ -19,9 +19,7 @@ uvgrtp::holepuncher::~holepuncher()
 
 rtp_error_t uvgrtp::holepuncher::start()
 {
-    if (!(runner_ = new std::thread(&uvgrtp::holepuncher::keepalive, this)))
-        return RTP_MEMORY_ERROR;
-
+    runner_ = new std::thread(&uvgrtp::holepuncher::keepalive, this);
     runner_->detach();
     return uvgrtp::runner::start();
 }

--- a/src/media_stream.cc
+++ b/src/media_stream.cc
@@ -73,8 +73,7 @@ rtp_error_t uvgrtp::media_stream::init_connection()
 {
     rtp_error_t ret = RTP_OK;
 
-    if (!(socket_ = new uvgrtp::socket(ctx_config_.flags)))
-        return ret;
+    socket_ = new uvgrtp::socket(ctx_config_.flags);
 
     if ((ret = socket_->init(AF_INET, SOCK_DGRAM, 0)) != RTP_OK)
         return ret;
@@ -120,8 +119,7 @@ rtp_error_t uvgrtp::media_stream::create_media(rtp_format_t fmt)
 {
     switch (fmt_) {
         case RTP_FORMAT_H264:
-            if (!(media_ = new uvgrtp::formats::h264(socket_, rtp_, ctx_config_.flags)))
-                return RTP_MEMORY_ERROR;
+            media_ = new uvgrtp::formats::h264(socket_, rtp_, ctx_config_.flags);
 
             pkt_dispatcher_->install_aux_handler(
                 rtp_handler_key_,
@@ -132,8 +130,7 @@ rtp_error_t uvgrtp::media_stream::create_media(rtp_format_t fmt)
             return RTP_OK;
 
         case RTP_FORMAT_H265:
-            if (!(media_ = new uvgrtp::formats::h265(socket_, rtp_, ctx_config_.flags)))
-                return RTP_MEMORY_ERROR;
+            media_ = new uvgrtp::formats::h265(socket_, rtp_, ctx_config_.flags);
 
             pkt_dispatcher_->install_aux_handler(
                 rtp_handler_key_,
@@ -144,8 +141,7 @@ rtp_error_t uvgrtp::media_stream::create_media(rtp_format_t fmt)
             return RTP_OK;
 
         case RTP_FORMAT_H266:
-            if (!(media_ = new uvgrtp::formats::h266(socket_, rtp_, ctx_config_.flags)))
-                return RTP_MEMORY_ERROR;
+            media_ = new uvgrtp::formats::h266(socket_, rtp_, ctx_config_.flags);
 
             pkt_dispatcher_->install_aux_handler(
                 rtp_handler_key_,
@@ -157,8 +153,7 @@ rtp_error_t uvgrtp::media_stream::create_media(rtp_format_t fmt)
 
         case RTP_FORMAT_OPUS:
         case RTP_FORMAT_GENERIC:
-            if (!(media_ = new uvgrtp::formats::media(socket_, rtp_, ctx_config_.flags)))
-                return RTP_MEMORY_ERROR;
+            media_ = new uvgrtp::formats::media(socket_, rtp_, ctx_config_.flags);
 
             pkt_dispatcher_->install_aux_handler(
                 rtp_handler_key_,
@@ -195,14 +190,11 @@ rtp_error_t uvgrtp::media_stream::init()
         return free_resources(RTP_GENERIC_ERROR);
     }
 
-    if (!(pkt_dispatcher_ = new uvgrtp::pkt_dispatcher()))
-        return free_resources(RTP_MEMORY_ERROR);
+    pkt_dispatcher_ = new uvgrtp::pkt_dispatcher();
 
-    if (!(rtp_ = new uvgrtp::rtp(fmt_)))
-        return free_resources(RTP_MEMORY_ERROR);
+    rtp_ = new uvgrtp::rtp(fmt_);
 
-    if (!(rtcp_ = new uvgrtp::rtcp(rtp_, ctx_config_.flags)))
-        return free_resources(RTP_MEMORY_ERROR);
+    rtcp_ = new uvgrtp::rtcp(rtp_, ctx_config_.flags);
 
     socket_->install_handler(rtcp_, rtcp_->send_packet_handler_vec);
 
@@ -213,8 +205,7 @@ rtp_error_t uvgrtp::media_stream::init()
         return free_resources(RTP_MEMORY_ERROR);
 
     if (ctx_config_.flags & RCE_HOLEPUNCH_KEEPALIVE) {
-        if (!(holepuncher_ = new uvgrtp::holepuncher(socket_)))
-            return free_resources(RTP_MEMORY_ERROR);
+        holepuncher_ = new uvgrtp::holepuncher(socket_);
         holepuncher_->start();
     }
 
@@ -236,35 +227,30 @@ rtp_error_t uvgrtp::media_stream::init(uvgrtp::zrtp *zrtp)
         return RTP_GENERIC_ERROR;
     }
 
-    if (!(pkt_dispatcher_ = new uvgrtp::pkt_dispatcher()))
-        return free_resources(RTP_MEMORY_ERROR);
+    pkt_dispatcher_ = new uvgrtp::pkt_dispatcher();
 
-    if (!(rtp_ = new uvgrtp::rtp(fmt_)))
-        return free_resources(RTP_MEMORY_ERROR);
+    rtp_ = new uvgrtp::rtp(fmt_);
 
     if ((ret = zrtp->init(rtp_->get_ssrc(), socket_, addr_out_)) != RTP_OK) {
         LOG_WARN("Failed to initialize ZRTP for media stream!");
         return free_resources(ret);
     }
 
-    if (!(srtp_ = new uvgrtp::srtp()))
-        return free_resources(RTP_MEMORY_ERROR);
+    srtp_ = new uvgrtp::srtp();
 
     if ((ret = srtp_->init_zrtp(SRTP, ctx_config_.flags, rtp_, zrtp)) != RTP_OK) {
         LOG_WARN("Failed to initialize SRTP for media stream!");
         return free_resources(ret);
     }
 
-    if (!(srtcp_ = new uvgrtp::srtcp()))
-        return free_resources(RTP_MEMORY_ERROR);
+    srtcp_ = new uvgrtp::srtcp();
 
     if ((ret = srtcp_->init_zrtp(SRTCP, ctx_config_.flags, rtp_, zrtp)) != RTP_OK) {
         LOG_ERROR("Failed to initialize SRTCP for media stream!");
         return free_resources(ret);
     }
 
-    if (!(rtcp_ = new uvgrtp::rtcp(rtp_, srtcp_, ctx_config_.flags)))
-        return free_resources(RTP_MEMORY_ERROR);
+    rtcp_ = new uvgrtp::rtcp(rtp_, srtcp_, ctx_config_.flags);
 
     socket_->install_handler(rtcp_, rtcp_->send_packet_handler_vec);
     socket_->install_handler(srtp_, srtp_->send_packet_handler);
@@ -279,8 +265,7 @@ rtp_error_t uvgrtp::media_stream::init(uvgrtp::zrtp *zrtp)
         return free_resources(RTP_MEMORY_ERROR);
 
     if (ctx_config_.flags & RCE_HOLEPUNCH_KEEPALIVE) {
-        if (!(holepuncher_ = new uvgrtp::holepuncher(socket_)))
-            return free_resources(RTP_MEMORY_ERROR);
+        holepuncher_ = new uvgrtp::holepuncher(socket_);
         holepuncher_->start();
     }
 
@@ -312,30 +297,25 @@ rtp_error_t uvgrtp::media_stream::add_srtp_ctx(uint8_t *key, uint8_t *salt)
     if ((flags_ & srtp_flags) != srtp_flags)
         return free_resources(RTP_NOT_SUPPORTED);
 
-    if (!(pkt_dispatcher_ = new uvgrtp::pkt_dispatcher()))
-        return free_resources(RTP_MEMORY_ERROR);
+    pkt_dispatcher_ = new uvgrtp::pkt_dispatcher();
 
-    if (!(rtp_ = new uvgrtp::rtp(fmt_)))
-        return free_resources(RTP_MEMORY_ERROR);
+    rtp_ = new uvgrtp::rtp(fmt_);
 
-    if (!(srtp_ = new uvgrtp::srtp()))
-        return free_resources(RTP_MEMORY_ERROR);
+    srtp_ = new uvgrtp::srtp();
 
     if ((ret = srtp_->init_user(SRTP, ctx_config_.flags, key, salt)) != RTP_OK) {
         LOG_WARN("Failed to initialize SRTP for media stream!");
         return free_resources(ret);
     }
 
-    if (!(srtcp_ = new uvgrtp::srtcp()))
-        return free_resources(RTP_MEMORY_ERROR);
+    srtcp_ = new uvgrtp::srtcp();
 
     if ((ret = srtcp_->init_user(SRTCP, ctx_config_.flags, key, salt)) != RTP_OK) {
         LOG_WARN("Failed to initialize SRTCP for media stream!");
         return free_resources(ret);
     }
 
-    if (!(rtcp_ = new uvgrtp::rtcp(rtp_, srtcp_, ctx_config_.flags)))
-        return free_resources(RTP_MEMORY_ERROR);
+    rtcp_ = new uvgrtp::rtcp(rtp_, srtcp_, ctx_config_.flags);
 
     socket_->install_handler(rtcp_, rtcp_->send_packet_handler_vec);
     socket_->install_handler(srtp_, srtp_->send_packet_handler);
@@ -349,8 +329,7 @@ rtp_error_t uvgrtp::media_stream::add_srtp_ctx(uint8_t *key, uint8_t *salt)
         return free_resources(RTP_MEMORY_ERROR);
 
     if (ctx_config_.flags & RCE_HOLEPUNCH_KEEPALIVE) {
-        if (!(holepuncher_ = new uvgrtp::holepuncher(socket_)))
-            return free_resources(RTP_MEMORY_ERROR);
+        holepuncher_ = new uvgrtp::holepuncher(socket_);
         holepuncher_->start();
     }
 

--- a/src/pkt_dispatch.cc
+++ b/src/pkt_dispatch.cc
@@ -26,9 +26,7 @@ uvgrtp::pkt_dispatcher::~pkt_dispatcher()
 
 rtp_error_t uvgrtp::pkt_dispatcher::start(uvgrtp::socket *socket, int flags)
 {
-    if (!(runner_ = new std::thread(&uvgrtp::pkt_dispatcher::runner, this, socket, flags)))
-        return RTP_MEMORY_ERROR;
-
+    runner_ = new std::thread(&uvgrtp::pkt_dispatcher::runner, this, socket, flags);
     runner_->detach();
     return uvgrtp::runner::start();
 }

--- a/src/queue.cc
+++ b/src/queue.cc
@@ -332,10 +332,7 @@ rtp_error_t uvgrtp::frame_queue::enqueue_message(std::vector<std::pair<size_t, u
         for (auto& buffer : buffers)
             total += buffer.first;
 
-        if (!(mem = ptr = new uint8_t[total])) {
-            LOG_ERROR("Failed to allocate memory for copy block!");
-            return RTP_MEMORY_ERROR;
-        }
+        mem = ptr = new uint8_t[total];
 
         for (auto& buffer : buffers) {
             memcpy(ptr, buffer.second, buffer.first);

--- a/src/rtcp.cc
+++ b/src/rtcp.cc
@@ -56,11 +56,7 @@ rtp_error_t uvgrtp::rtcp::start()
     }
     active_ = true;
 
-    if (!(runner_ = new std::thread(rtcp_runner, this))) {
-        active_ = false;
-        LOG_ERROR("Failed to create RTCP thread!");
-        return RTP_MEMORY_ERROR;
-    }
+    runner_ = new std::thread(rtcp_runner, this);
     runner_->detach();
 
     return RTP_OK;
@@ -111,13 +107,11 @@ rtp_error_t uvgrtp::rtcp::add_participant(std::string dst_addr, uint16_t dst_por
     rtp_error_t ret;
     rtcp_participant *p;
 
-    if (!(p = new rtcp_participant))
-        return RTP_MEMORY_ERROR;
+    p = new rtcp_participant();
 
     zero_stats(&p->stats);
 
-    if (!(p->socket = new uvgrtp::socket(0)))
-        return RTP_MEMORY_ERROR;
+    p->socket = new uvgrtp::socket(0);
 
     if ((ret = p->socket->init(AF_INET, SOCK_DGRAM, 0)) != RTP_OK)
         return ret;
@@ -173,8 +167,7 @@ rtp_error_t uvgrtp::rtcp::add_participant(uint32_t ssrc)
     /* RTCP is not in use for this media stream,
      * create a "fake" participant that is only used for storing statistics information */
     if (initial_participants_.empty()) {
-        if (!(participants_[ssrc] = new rtcp_participant))
-            return RTP_MEMORY_ERROR;
+        participants_[ssrc] = new rtcp_participant();
         zero_stats(&participants_[ssrc]->stats);
     } else {
         participants_[ssrc] = initial_participants_.back();

--- a/src/rtcp/app.cc
+++ b/src/rtcp/app.cc
@@ -80,10 +80,7 @@ rtp_error_t uvgrtp::rtcp::send_app_packet(char *name, uint8_t subtype, size_t pa
     frame_size += 4; /* name */
     frame_size += payload_len;
 
-    if (!(frame = new uint8_t[frame_size])) {
-        LOG_ERROR("Failed to allocate space for RTCP Receiver Report");
-        return RTP_MEMORY_ERROR;
-    }
+    frame = new uint8_t[frame_size];
     memset(frame, 0, frame_size);
 
     frame[0] = (2 << 6) | (0 << 5) | (subtype & 0x1f);

--- a/src/rtcp/bye.cc
+++ b/src/rtcp/bye.cc
@@ -37,10 +37,7 @@ rtp_error_t uvgrtp::rtcp::send_bye_packet(std::vector<uint32_t> ssrcs)
     frame_size  = 4; /* rtcp header */
     frame_size += ssrcs.size() * sizeof(uint32_t);
 
-    if (!(frame = new uint8_t[frame_size])) {
-        LOG_ERROR("Failed to allocate space for RTCP Receiver Report");
-        return RTP_MEMORY_ERROR;
-    }
+    frame = new uint8_t[frame_size];
     memset(frame, 0, frame_size);
 
     frame[0] = (2 << 6) | (0 << 5) | (ssrcs.size() & 0x1f);

--- a/src/rtcp/receiver.cc
+++ b/src/rtcp/receiver.cc
@@ -118,10 +118,7 @@ rtp_error_t uvgrtp::rtcp::generate_receiver_report()
     if (flags_ & RCE_SRTP)
         frame_size += UVG_SRTCP_INDEX_LENGTH + UVG_AUTH_TAG_LENGTH;
 
-    if (!(frame = new uint8_t[frame_size])) {
-        LOG_ERROR("Failed to allocate space for RTCP Receiver Report");
-        return RTP_MEMORY_ERROR;
-    }
+    frame = new uint8_t[frame_size];
     memset(frame, 0, frame_size);
 
     frame[0] = (2 << 6) | (0 << 5) | num_receivers_;

--- a/src/rtcp/sdes.cc
+++ b/src/rtcp/sdes.cc
@@ -103,10 +103,7 @@ rtp_error_t uvgrtp::rtcp::send_sdes_packet(std::vector<uvgrtp::frame::rtcp_sdes_
     for (auto& item : items)
         frame_size += item.length;
 
-    if (!(frame = new uint8_t[frame_size])) {
-        LOG_ERROR("Failed to allocate space for RTCP Receiver Report");
-        return RTP_MEMORY_ERROR;
-    }
+    frame = new uint8_t[frame_size];
     memset(frame, 0, frame_size);
 
     // header |V=2|P|    SC   |  PT=SDES=202  |             length            |

--- a/src/rtcp/sender.cc
+++ b/src/rtcp/sender.cc
@@ -117,10 +117,7 @@ rtp_error_t uvgrtp::rtcp::generate_sender_report()
     if (flags_ & RCE_SRTP)
         frame_size += UVG_SRTCP_INDEX_LENGTH + UVG_AUTH_TAG_LENGTH;
 
-    if (!(frame = new uint8_t[frame_size])) {
-        LOG_ERROR("Failed to allocate space for RTCP Receiver Report");
-        return RTP_MEMORY_ERROR;
-    }
+    frame = new uint8_t[frame_size];
     memset(frame, 0, frame_size);
 
     frame[0] = (2 << 6) | (0 << 5) | num_receivers_;

--- a/src/session.cc
+++ b/src/session.cc
@@ -50,13 +50,6 @@ uvgrtp::media_stream *uvgrtp::session::create_stream(int r_port, int s_port, rtp
     else
         stream = new uvgrtp::media_stream(addr_, laddr_, r_port, s_port, fmt, flags);
 
-    if (!stream) {
-        LOG_ERROR("Failed to create media stream for %s:%d -> %s:%d",
-            (laddr_ == "") ? "0.0.0.0" : laddr_.c_str(), s_port, addr_.c_str(), r_port
-        );
-        return nullptr;
-    }
-
     if (flags & RCE_SRTP) {
         if (!uvgrtp::crypto::enabled()) {
             LOG_ERROR("Recompile uvgRTP with -D__RTP_CRYPTO__");
@@ -75,10 +68,7 @@ uvgrtp::media_stream *uvgrtp::session::create_stream(int r_port, int s_port, rtp
             }
 
             if (!zrtp_) {
-                if (!(zrtp_ = new uvgrtp::zrtp())) {
-                    rtp_errno = RTP_MEMORY_ERROR;
-                    return nullptr;
-                }
+                zrtp_ = new uvgrtp::zrtp();
             }
 
             if (stream->init(zrtp_) != RTP_OK) {

--- a/src/socket.cc
+++ b/src/socket.cc
@@ -336,10 +336,7 @@ rtp_error_t uvgrtp::socket::__sendtov(
     int sent_bytes = 0;
     struct mmsghdr *hptr, *headers;
 
-    if (!(hptr = headers = new struct mmsghdr[buffers.size()])) {
-        LOG_ERROR("Failed to allocate space for struct mmsghdr!");
-        return RTP_MEMORY_ERROR;
-    }
+    hptr = headers = new struct mmsghdr[buffers.size()];
 
     for (size_t i = 0; i < buffers.size(); ++i) {
         headers[i].msg_hdr.msg_iov        = new struct iovec[buffers[i].size()];

--- a/src/srtp/base.cc
+++ b/src/srtp/base.cc
@@ -198,34 +198,13 @@ rtp_error_t uvgrtp::base_srtp::init(int type, int flags, size_t key_size)
 
 rtp_error_t uvgrtp::base_srtp::allocate_crypto_ctx(size_t key_size)
 {
-    if (!(srtp_ctx_->key_ctx.master.local_key = new uint8_t[key_size])) {
-        LOG_ERROR("Failed to allocate space for local master key");
-        return RTP_MEMORY_ERROR;
-    }
+    srtp_ctx_->key_ctx.master.local_key = new uint8_t[key_size];
 
-    if (!(srtp_ctx_->key_ctx.master.remote_key = new uint8_t[key_size])) {
-        LOG_ERROR("Failed to allocate space for remote master key");
+    srtp_ctx_->key_ctx.master.remote_key = new uint8_t[key_size];
 
-        delete[] srtp_ctx_->key_ctx.master.local_key;
-        return RTP_MEMORY_ERROR;
-    }
+    srtp_ctx_->key_ctx.local.enc_key = new uint8_t[key_size];
 
-    if (!(srtp_ctx_->key_ctx.local.enc_key = new uint8_t[key_size])) {
-        LOG_ERROR("Failed to allocate space for local session key");
-
-        delete[] srtp_ctx_->key_ctx.master.local_key;
-        delete[] srtp_ctx_->key_ctx.master.remote_key;
-        return RTP_MEMORY_ERROR;
-    }
-
-    if (!(srtp_ctx_->key_ctx.remote.enc_key = new uint8_t[key_size])) {
-        LOG_ERROR("Failed to allocate space for remote session key");
-
-        delete[] srtp_ctx_->key_ctx.master.local_key;
-        delete[] srtp_ctx_->key_ctx.master.remote_key;
-        delete[] srtp_ctx_->key_ctx.local.enc_key;
-        return RTP_MEMORY_ERROR;
-    }
+    srtp_ctx_->key_ctx.remote.enc_key = new uint8_t[key_size];
 
     return RTP_OK;
 }
@@ -238,9 +217,6 @@ rtp_error_t uvgrtp::base_srtp::init_zrtp(int type, int flags, uvgrtp::rtp *rtp, 
         return RTP_INVALID_VALUE;
 
     rtp_error_t ret = allocate_crypto_ctx(AES128_KEY_SIZE);
-
-    if (ret != RTP_OK)
-        return ret;
 
     /* ZRTP key derivation function expects the keys lengths to be given in bits */
     ret = zrtp->get_srtp_keys(


### PR DESCRIPTION
There where a lot of if statements to check if a new operation would return null
Because "new" can never return null, at least in the official standard, we remove those.

I did no put any effort to in correcting anything but removing those if's
The cleanings I removed would never have been called anyway, so no break should be happening.

I think it is necessary to replace a lot of those pointers with smart pointers and do the cleaning in RAII fashion, 
but that should be part of another PR