### PR TITLE
build: Completely Redesigned CMake files (#44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/*
 tags
 *a.out
 docs/latex
+/cmake-build*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,139 +1,199 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 
+#
+# Project Configuration
+#
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-project(uvgrtp)
+include(cmake/ProjectDetails.cmake)
+project(uvgrtp
+        VERSION ${uvgrtp_VER}
+        DESCRIPTION ${uvgrtp_DESCR}
+        HOMEPAGE_URL ${uvgrtp_URL}
+        LANGUAGES CXX)
 
-option(DISABLE_CRYPTO "Do not build uvgRTP with crypto enabled")
-option(PTHREADS_PATH  "Path to POSIX threads static library")
-option(CRYPTOPP_PATH  "Path to Crypto++ static library")
+include(cmake/FindDependencies.cmake)
+include(cmake/Versioning.cmake)
+option(DISABLE_CRYPTO "Do not build uvgRTP with crypto enabled" OFF)
 
-add_library(uvgrtp STATIC
-    src/clock.cc
-    src/crypto.cc
-    src/dispatch.cc
-    src/frame.cc
-    src/hostname.cc
-    src/lib.cc
-    src/media_stream.cc
-    src/mingw_inet.cc
-    src/multicast.cc
-    src/pkt_dispatch.cc
-    src/poll.cc
-    src/queue.cc
-    src/random.cc
-    src/rtcp.cc
-    src/rtp.cc
-    src/runner.cc
-    src/session.cc
-    src/socket.cc
-    src/zrtp.cc
-    src/holepuncher.cc
-    src/formats/media.cc
-    src/formats/h26x.cc
-    src/formats/h264.cc
-    src/formats/h265.cc
-    src/formats/h266.cc
-    src/zrtp/zrtp_receiver.cc
-    src/zrtp/hello.cc
-    src/zrtp/hello_ack.cc
-    src/zrtp/commit.cc
-    src/zrtp/dh_kxchng.cc
-    src/zrtp/confirm.cc
-    src/zrtp/confack.cc
-    src/zrtp/error.cc
-    src/zrtp/zrtp_message.cc
-    src/srtp/base.cc
-    src/srtp/srtp.cc
-    src/srtp/srtcp.cc
-)
+add_library(${PROJECT_NAME})
+set_target_properties(${PROJECT_NAME} PROPERTIES
+        SOVERSION ${PROJECT_VERSION_MAJOR}
+        VERSION ${LIBRARY_VERSION}
+        )
 
-target_include_directories(uvgrtp
-    PUBLIC
-        ${PROJECT_SOURCE_DIR}/include
-)
+target_sources(${PROJECT_NAME} PRIVATE
+        src/clock.cc
+        src/crypto.cc
+        src/dispatch.cc
+        src/frame.cc
+        src/hostname.cc
+        src/lib.cc
+        src/media_stream.cc
+        src/mingw_inet.cc
+        src/multicast.cc
+        src/pkt_dispatch.cc
+        src/poll.cc
+        src/queue.cc
+        src/random.cc
+        src/rtcp.cc
+        src/rtp.cc
+        src/runner.cc
+        src/session.cc
+        src/socket.cc
+        src/zrtp.cc
+        src/holepuncher.cc
+        src/formats/media.cc
+        src/formats/h26x.cc
+        src/formats/h264.cc
+        src/formats/h265.cc
+        src/formats/h266.cc
+        src/zrtp/zrtp_receiver.cc
+        src/zrtp/hello.cc
+        src/zrtp/hello_ack.cc
+        src/zrtp/commit.cc
+        src/zrtp/dh_kxchng.cc
+        src/zrtp/confirm.cc
+        src/zrtp/confack.cc
+        src/zrtp/error.cc
+        src/zrtp/zrtp_message.cc
+        src/srtp/base.cc
+        src/srtp/srtp.cc
+        src/srtp/srtcp.cc
+        )
 
-set(LIBRARY_PATHS "")
+# Including header files so VisualStudio will list them correctly
+target_sources(${PROJECT_NAME} PRIVATE
+        src/random.hh
+        src/dispatch.hh
+        src/holepuncher.hh
+        src/hostname.hh
+        src/mingw_inet.hh
+        src/multicast.hh
+        src/pkt_dispatch.hh
+        src/poll.hh
+        src/rtp.hh
+        src/zrtp.hh
+        src/queue.hh
+        include/util.hh
+        include/clock.hh
+        include/crypto.hh
+        include/debug.hh
+        include/frame.hh
+        include/lib.hh
+        include/media_stream.hh
+        include/rtcp.hh
+        include/runner.hh
+        include/session.hh
+        include/socket.hh
+        )
 
-if (PTHREADS_PATH)
-    separate_arguments(LIBRARY_PATHS NATIVE_COMMAND ${PTHREADS_PATH})
-endif (PTHREADS_PATH)
+if(WIN32)
+    set(WINLIBS wsock32 ws2_32)
+endif()
 
-if (CRYPTOPP_PATH AND NOT DISABLE_CRYPTO)
-    separate_arguments(LIBRARY_PATHS NATIVE_COMMAND "${LIBRARY_PATHS} ${CRYPTOPP_PATH}")
-endif (CRYPTOPP_PATH AND NOT DISABLE_CRYPTO)
+target_link_libraries(${PROJECT_NAME}
+        PRIVATE
+            Threads::Threads
+            ${PROJECT_NAME}_version
+            ${WINLIBS}
+        )
+
+target_include_directories(${PROJECT_NAME}
+        PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
+        PUBLIC $<INSTALL_INTERFACE:include>
+        )
+
+if(MSVC)
+    target_compile_options(${PROJECT_NAME} PRIVATE /Zc:__cplusplus)
+else()
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic #[[-Werror]])
+endif()
+
+if (DISABLE_CRYPTO)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE __RTP_NO_CRYPTO__)
+endif()
 
 if (UNIX)
-    set(COMPILER_FLAGS "-Wall -Wextra -Wuninitialized -Wshadow -O2 -g -march=native")
-    
-    if (DISABLE_CRYPTO)
-        string(APPEND COMPILER_FLAGS " -D__RTP_NO_CRYPTO__")
-    endif(DISABLE_CRYPTO)
-
     # Check the getrandom() function exists
     include(CheckCXXSymbolExists)
     check_cxx_symbol_exists(getrandom sys/random.h HAVE_GETRANDOM)
 
     if(HAVE_GETRANDOM)
-        add_compile_definitions(HAVE_GETRANDOM=1)
+        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_GETRANDOM=1)
     endif()
-
-    # if (NOT "${LIBRARY_PATHS}" STREQUAL "")
-    #     add_custom_command(TARGET uvgrtp POST_BUILD
-    #         COMMAND ar crsT ARGS libuvgrtp_thin.a libuvgrtp.a ${LIBRARY_PATHS}
-    #         BYPRODUCTS libuvgrtp_thin.a
-    #         COMMENT "Creating combined archive"
-    #     )
-    #     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libuvgrtp_thin.a
-    #             RENAME libuvgrtp.a
-    #             DESTINATION /usr/local/lib
-    #     )
-    # else (NOT "${LIBRARY_PATHS}" STREQUAL "")
-        install(TARGETS uvgrtp
-                ARCHIVE
-                DESTINATION /usr/local/lib
-        )
-    # endif (NOT "${LIBRARY_PATHS}" STREQUAL "")
-
-    install(DIRECTORY include/ DESTINATION /usr/local/include/uvgrtp
-            FILES_MATCHING PATTERN "*.hh"
-    )
 endif (UNIX)
 
-if (WIN32)
-    if(MSVC)
-	    # /Zc:__cplusplus makes it so the correct c++ version is defined 
-        set(COMPILER_FLAGS "/O2 /Zc:__cplusplus")
-    else(MSVC)
-        set(COMPILER_FLAGS "-O2")
-    endif(MSVC)
-    SET(OUT_DIR ${CMAKE_BINARY_DIR}/Debug)
+add_subdirectory(test EXCLUDE_FROM_ALL)
 
-    if (DISABLE_CRYPTO)
-        if(MSVC)
-            string(APPEND COMPILER_FLAGS " /D__RTP_NO_CRYPTO__")
-        else(MSVC)
-            string(APPEND COMPILER_FLAGS " -D__RTP_NO_CRYPTO__")
-        endif(MSVC)
-    endif(DISABLE_CRYPTO)
+#
+# Install
+#
+# Define install target, install libraries and archives (static libraries) to "<prefix>/..."
+include(GNUInstallDirs)
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_version EXPORT ${PROJECT_NAME}Targets
+        LIBRARY
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT ${PROJECT_NAME}_Runtime
+        ARCHIVE
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT ${PROJECT_NAME}_Runtime
+        RUNTIME
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
+            COMPONENT ${PROJECT_NAME}_Runtime)
 
-    # if (NOT "${LIBRARY_PATHS}" STREQUAL "")
-    #     add_custom_command(TARGET uvgrtp POST_BUILD
-    #         COMMAND lib /out:${OUT_DIR}/uvgrtp.lib ${OUT_DIR}/uvgrtp.lib ${LIBRARY_PATHS}
-    #         BYPRODUCTS uvgrtp.lib
-    #         COMMENT "Creating combined archive"
-    #     )
-    # else (NOT "${LIBRARY_PATHS}" STREQUAL "")
-        install(TARGETS uvgrtp
-                ARCHIVE
-                DESTINATION ${PROJECT_BINARY_DIR}/lib
+#Copy all header files to the <prefix>/include/uvgrtp directory
+file(GLOB DEPLOY_FILES_AND_DIRS "${CMAKE_SOURCE_DIR}/include/*")
+install(FILES ${DEPLOY_FILES_AND_DIRS}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/
+        COMPONENT ${PROJECT_NAME}_Develop)
+
+#Create a File representing the current library version
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
+        COMPATIBILITY SameMajorVersion
+)
+
+#Create a Targets file representing exported targets (for usage within the build tree)
+export(EXPORT ${PROJECT_NAME}Targets
+        FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Targets.cmake"
+        NAMESPACE ${PROJECT_NAME}::
         )
-    # endif (NOT "${LIBRARY_PATHS}" STREQUAL "")
 
-    install(DIRECTORY include/ DESTINATION ${PROJECT_BINARY_DIR}/include
-            FILES_MATCHING PATTERN "*.hh"
-    )
-endif (WIN32)
+#Copy "cmake/uvgrtpConfig.cmake" to "${CMAKE_CURRENT_BINARY_DIR}/uvgrtp/uvgrtpConfig.cmake"
+configure_file(cmake/${PROJECT_NAME}Config.cmake
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake"
+        COPYONLY
+        )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMPILER_FLAGS}")
+#Copy "cmake/uvgrtpMacros.cmake" to "${CMAKE_CURRENT_BINARY_DIR}/uvgrtp/uvgrtpMacros.cmake"
+configure_file(cmake/${PROJECT_NAME}Macros.cmake
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Macros.cmake"
+        COPYONLY
+        )
+
+#
+# Adding target to installing cmake package
+#
+set(ConfigPackageLocation lib/cmake/${PROJECT_NAME})
+install(EXPORT ${PROJECT_NAME}Targets
+        FILE ${PROJECT_NAME}Targets.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${ConfigPackageLocation}
+        )
+
+install(FILES cmake/${PROJECT_NAME}Config.cmake cmake/${PROJECT_NAME}Macros.cmake
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
+        DESTINATION ${ConfigPackageLocation}
+        COMPONENT uvgRTPMain
+)
+
+#
+# Packaging
+#
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    add_subdirectory(packaging)
+endif()

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -1,0 +1,30 @@
+#
+# PThread
+#
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package( Threads REQUIRED )
+
+#
+# Git
+#
+find_package(Git)
+
+#
+# GTest / GMock
+#
+include(FetchContent)
+FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG        release-1.11.0
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(googletest)
+add_library(GTest::GMock ALIAS gmock)
+add_library(GTest::GMockMain ALIAS gmock_main)
+add_library(GTest::GTest ALIAS gtest)
+add_library(GTest::GTestMain ALIAS gtest_main)

--- a/cmake/ProjectDetails.cmake
+++ b/cmake/ProjectDetails.cmake
@@ -1,0 +1,3 @@
+set(uvgrtp_VER 2.0.0)
+set(uvgrtp_DESCR "uvgRTP is an Real-Time Transport Protocol (RTP) library written in C++ with a focus on simple to use and high-efficiency media delivery over the internet")
+set(uvgrtp_URL "https://github.com/ultravideo/uvgRTP")

--- a/cmake/Versioning.cmake
+++ b/cmake/Versioning.cmake
@@ -1,0 +1,33 @@
+if(GIT_FOUND)
+    execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+            RESULT_VARIABLE result
+            OUTPUT_VARIABLE uvgrtp_GIT_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(result)
+        message(WARNING "Failed to get git hash: ${result}")
+    endif()
+endif()
+
+if(uvgrtp_GIT_HASH)
+    SET(uvgrtp_GIT_HASH "-${uvgrtp_GIT_HASH}")
+endif()
+
+option(RELEASE_VERSION "Create a release version" OFF)
+if(RELEASE_VERSION)
+    set (LIBRARY_VERSION ${PROJECT_VERSION})
+else()
+    set (LIBRARY_VERSION ${PROJECT_VERSION}${uvgrtp_GIT_HASH})
+endif()
+
+configure_file(cmake/uvgrtp_version.cpp.in uvgrtp_version.cpp
+        @ONLY
+        )
+add_library(${PROJECT_NAME}_version OBJECT
+        ${CMAKE_CURRENT_BINARY_DIR}/uvgrtp_version.cpp)
+target_include_directories(${PROJECT_NAME}_version
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+        )
+
+

--- a/cmake/uvgrtpConfig.cmake
+++ b/cmake/uvgrtpConfig.cmake
@@ -1,0 +1,7 @@
+include("${CMAKE_CURRENT_LIST_DIR}/uvgrtpTargets.cmake")
+include(CMakeFindDependencyMacro)
+
+find_dependency(Threads)
+
+include("${CMAKE_CURRENT_LIST_DIR}/uvgrtpTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/uvgrtpMacros.cmake")

--- a/cmake/uvgrtp_version.cpp.in
+++ b/cmake/uvgrtp_version.cpp.in
@@ -1,0 +1,16 @@
+#include "uvgrtp_version.h"
+
+#include <cstdint>
+#include <string>
+
+namespace uvgrtp {
+std::string get_uvgrtp_version() { return "@uvgrtp_VERSION@"; }
+
+uint16_t get_uvgrtp_version_major() { return @uvgrtp_VERSION_MAJOR@; }
+
+uint16_t get_uvgrtp_version_minor() { return @uvgrtp_VERSION_MINOR@; }
+
+uint16_t get_uvgrtp_version_patch() { return @uvgrtp_VERSION_PATCH@; }
+
+std::string get_git_hash() {return "@uvgrtp_GIT_HASH@";}
+} // namespace uvgrtp

--- a/include/uvgrtp_version.h
+++ b/include/uvgrtp_version.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace uvgrtp {
+std::string get_uvgrtp_version();
+uint16_t get_uvgrtp_version_major();
+uint16_t get_uvgrtp_version_minor();
+uint16_t get_uvgrtp_version_patch();
+std::string get_git_hash();
+} // namespace uvgrtp

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -1,0 +1,71 @@
+set(CPACK_COMPONENTS_ALL ${PROJECT_NAME}_Runtime ${PROJECT_NAME}_Develop)
+set(CPACK_PACKAGE_NAME   ${PROJECT_NAME})
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY ${uvgrtp_DESCR})
+set(CPACK_PACKAGE_INSTALL_DIRECTORY ${CPACK_PACKAGE_NAME})
+set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+set(CPACK_VERBATIM_VARIABLES YES)
+set(CPACK_PACKAGE_CONTACT https://github.com/polusto)
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER polusto)
+set(CPACK_RPM_COMPONENT_INSTALL TRUE)
+set(CPACK_DEB_COMPONENT_INSTALL TRUE)
+set(CPACK_COMPONENTS_GROUPING ONE_PER_GROUP)
+set(CPACK_DEBIAN_UVGRTP_DEVELOP_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}-dev.deb")
+set(CPACK_DEBIAN_UVGRTP_RUNTIME_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}-${CMAKE_HOST_SYSTEM_PROCESSOR}.deb")
+
+set(CPACK_PACKAGE_DESCRIPTION_FILE
+        ${CMAKE_CURRENT_LIST_DIR}/Description.txt
+        )
+set(CPACK_RESOURCE_FILE_WELCOME
+        ${CMAKE_CURRENT_LIST_DIR}/Welcome.txt
+        )
+set(CPACK_RESOURCE_FILE_LICENSE
+        ${CMAKE_CURRENT_LIST_DIR}/License.txt
+        )
+set(CPACK_RESOURCE_FILE_README
+        ${CMAKE_CURRENT_LIST_DIR}/Readme.txt
+        )
+set(CPACK_SOURCE_IGNORE_FILES
+        /\\.git/
+        /\\.circleci/
+        /\\.idea/
+        \\.swp
+        \\.orig
+        /CMakeLists\\.txt\\.user
+        /privateDir/
+        /cmake\\-build.*/
+        )
+include(CPack)
+
+if(WIN32)
+    set(CPACK_GENERATOR ZIP WIX)
+elseif(APPLE)
+    set(CPACK_GENERATOR TGZ productbuild)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(CPACK_GENERATOR TGZ RPM)
+else()
+    set(CPACK_GENERATOR TGZ)
+endif()
+
+cpack_add_component(${PROJECT_NAME}_Runtime
+        DISPLAY_NAME Runtime
+        Description "Shared libraries"
+        REQUIRED
+        INSTALL_TYPES Full Developer Minimal)
+
+cpack_add_component(${PROJECT_NAME}_Development
+        DISPLAY_NAME "Developer pre-requisites"
+        DESCRIPTION "Headers needed for development"
+        DEPENDS  ${PROJECT_NAME}_Runtime
+        INSTALL_TYPES Full Developer)
+
+cpack_add_component(${PROJECT_NAME}_Samples
+        DISPLAY_NAME "Code Samples"
+        INSTALL_TYPES Full Developer
+        DISABLED)
+
+cpack_add_install_type(Full)
+cpack_add_install_type(Minimal)
+cpack_add_install_type(Developer
+        DISPLAY_NAME "SDK Development")

--- a/packaging/Description.txt
+++ b/packaging/Description.txt
@@ -1,0 +1,1 @@
+Placeholder

--- a/packaging/License.txt
+++ b/packaging/License.txt
@@ -1,0 +1,1 @@
+Placeholder

--- a/packaging/Readme.txt
+++ b/packaging/Readme.txt
@@ -1,0 +1,1 @@
+Placeholder

--- a/packaging/Welcome.txt
+++ b/packaging/Welcome.txt
@@ -1,0 +1,1 @@
+Placeholder

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,20 @@
+project(uvgrtp_test)
+
+enable_testing()
+include(GoogleTest)
+
+add_executable(${PROJECT_NAME})
+target_sources(${PROJECT_NAME}
+        PRIVATE
+            main.cpp
+            TestGTest.cpp
+        )
+target_link_libraries(${PROJECT_NAME}
+        PRIVATE
+            GTest::GTestMain
+            uvgrtp
+        )
+
+gtest_add_tests(
+        TARGET ${PROJECT_NAME}
+)

--- a/test/TestGTest.cpp
+++ b/test/TestGTest.cpp
@@ -1,0 +1,6 @@
+#include "uvgrtp_version.h"
+#include <gtest/gtest.h>
+
+TEST(DefaultTest, ctor) {
+  EXPECT_STREQ("2.1.0", uvgrtp::get_uvgrtp_version().c_str());
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,0 +1,6 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Primary changes are:
- Versioning integrated in cmake build system with library for version usage in end user programs
- New minimum CMAke required version is 3.14
- Created install capabilities. Allows uvgRTP to be used in different scenarios for win and lin (mac-os still missing)
- Added testing environment with automatically fetched google test and some example test code.
- Added packaging capabilities (and some placeholders that have to be changed)