### PR TITLE
rtp: fix up handling of extension header

### DIFF
--- a/src/frame.cc
+++ b/src/frame.cc
@@ -57,8 +57,10 @@ rtp_error_t uvgrtp::frame::dealloc_frame(uvgrtp::frame::rtp_frame *frame)
     if (frame->csrc)
         delete[] frame->csrc;
 
-    if (frame->ext)
+    if (frame->ext) {
+        delete[] frame->ext->data;
         delete frame->ext;
+    }
 
     if (frame->probation)
         delete[] frame->probation;

--- a/src/rtp.cc
+++ b/src/rtp.cc
@@ -217,10 +217,11 @@ rtp_error_t uvgrtp::rtp::packet_handler(ssize_t size, void *packet, int flags, u
         LOG_DEBUG("Frame contains extension information");
         (*out)->ext = new uvgrtp::frame::ext_header;
 
-        (*out)->ext->type  = ntohs(*(uint16_t *)&ptr[0]);
-        (*out)->ext->len   = ntohs(*(uint32_t *)&ptr[1]);
-        (*out)->ext->data  = (uint8_t *)memdup(ptr + 2 * sizeof(uint16_t), (*out)->ext->len);
-        ptr               += 2 * sizeof(uint16_t) + (*out)->ext->len;
+        (*out)->ext->type    = ntohs(*(uint16_t *)&ptr[0]);
+        (*out)->ext->len     = ntohs(*(uint16_t *)&ptr[2]) * sizeof(uint32_t);
+        (*out)->ext->data    = (uint8_t *)memdup(ptr + 2 * sizeof(uint16_t), (*out)->ext->len);
+        (*out)->payload_len -= 2 * sizeof(uint16_t) + (*out)->ext->len;
+        ptr                 += 2 * sizeof(uint16_t) + (*out)->ext->len;
     }
 
     /* If padding is set to 1, the last byte of the payload indicates


### PR DESCRIPTION
Hi, 

I ran into a bit of a problem trying to use the extension header. I am reasonably confident this fix is correct for the one byte header case, however, the RFC also specifies a Two-Byte Header, which I'm not certain it is supported here at all.
https://datatracker.ietf.org/doc/html/rfc5285#section-4.2 

I hope this helps, I'm afraid I don't have any experience contributing to open source projects.

:-) Kolja

 - When setting the len field of the header, a bad offset of the source
   pointer was used
 - The len field of the header is a uint16 specifying payload length in
   multiples of 32 bit
 - Also, subtract the extension header length from the payload length
