### PR TITLE
H26x packet handling fixes

### DIFF
--- a/src/formats/h26x.cc
+++ b/src/formats/h26x.cc
@@ -313,14 +313,14 @@ error:
 
 rtp_error_t uvgrtp::formats::h26x::push_nal_unit(uint8_t *data, size_t data_len, bool more)
 {
-    if (data_len <= 3)
+    if (data_len == 0)
         return RTP_INVALID_VALUE;
 
     rtp_error_t ret = RTP_OK;
 
     size_t payload_size = rtp_ctx_->get_payload_size();
 
-    if (data_len - 3 <= payload_size) {
+    if (data_len <= payload_size) {
         /* If the small packet is handled we either wait for more small packets or
          * we already sent the data, so always return from this function after entering this branch */
         if ((ret = handle_small_packet(data, data_len, more)) != RTP_OK)

--- a/src/formats/h26x.cc
+++ b/src/formats/h26x.cc
@@ -321,8 +321,11 @@ rtp_error_t uvgrtp::formats::h26x::push_nal_unit(uint8_t *data, size_t data_len,
     size_t payload_size = rtp_ctx_->get_payload_size();
 
     if (data_len - 3 <= payload_size) {
+        /* If the small packet is handled we either wait for more small packets or
+         * we already sent the data, so always return from this function after entering this branch */
         if ((ret = handle_small_packet(data, data_len, more)) != RTP_OK)
             return ret;
+        return RTP_OK;
     }
     else {
         /* If smaller NALUs were queued before this NALU,


### PR DESCRIPTION
Fixed a bug causing a small packet handling to continue to the "large" packet handling, where it should never go.
Also added a fix removing the limitation of at least 3 bytes for the NALU, which should not be needed