### PR TITLE
[UVG-90] Find H264 start codes that are not 4byte aligned

### DIFF
--- a/src/formats/h26x.cc
+++ b/src/formats/h26x.cc
@@ -242,8 +242,8 @@ ssize_t uvgrtp::formats::h26x::find_h26x_start_code(
         }
 end:
         prev_z = cur_z;
-        pos += 4;
-        ptr += 4;
+        pos += 1;
+        ptr += 1;
         prev = value;
     }
 


### PR DESCRIPTION
This fixes the issue where start codes are not 4 byte aligned as expected by the current implementation.  As start codes can be 3 bytes instead of 4, this can lead to scenarios described in issue https://github.com/ultravideo/uvgRTP/issues/90  

This is solved by walking the memory by 1 byte instead of 4.  This unfortunately will impact the current performance as it cannot walk the memory 4 bytes at a time in start code detection.  However, the impact is minimal due to the performance of the 8byte haszero64 scan that is used to scan through the bytes before entering this slower walk described above.

Verified the following:
Built in Linux.
Output the produced RTP packets of the FIX to file and processed a binary comparison with another implementation (FFMPEG).  Verified all start codes are accounted for.  
Output the produced RTP Packets of the previous version to file and processed a binary comparison with FFMPEG verifying the start codes that are in the NALU that weren't properly parsed.

