### PR TITLE
build: fix error set_target_properties called with incorrect arguments number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ option(DISABLE_CRYPTO "Do not build uvgRTP with crypto enabled" OFF)
 
 add_library(${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME} PROPERTIES
-        SOVERSION ${PROJECT_VERSION_MAJOR}
-        VERSION ${LIBRARY_VERSION}
+        SOVERSION "${PROJECT_VERSION_MAJOR}"
+        VERSION "${LIBRARY_VERSION}"
         )
 set(UVGRTP_CXX_FLAGS "")
 set(UVGRTP_LINKER_FLAGS "")


### PR DESCRIPTION
PR fixes a compiler error about:
```
CMake Error at CMakeLists.txt:21 (set_target_properties):
set_target_properties called with incorrect number of arguments
```

When compiling the project with cmake within a ROS1 environment, the compiler termites with an error about "CMake Error at CMakeLists.txt:21 (set_target_properties): set_target_properties called with incorrect number of arguments".
Fixed by inserting cmake variables (within the command "set_target_properties") in double quotes.

I successfully tested the fix with both the standard build instructions for cmake, contained in the readme, and in the ROS1 environment. Please let me know if you can also double check this on your side.