### PR TITLE
build: Support building without a version number.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,12 @@ include(cmake/Versioning.cmake)
 option(DISABLE_CRYPTO "Do not build uvgRTP with crypto enabled" OFF)
 
 add_library(${PROJECT_NAME})
-set_target_properties(${PROJECT_NAME} PROPERTIES
+if("{LIBRARY_VERSION}")
+    set_target_properties(${PROJECT_NAME} PROPERTIES
         SOVERSION "${PROJECT_VERSION_MAJOR}"
         VERSION "${LIBRARY_VERSION}"
         )
+endif()
 set(UVGRTP_CXX_FLAGS "")
 set(UVGRTP_LINKER_FLAGS "")
 

--- a/cmake/Versioning.cmake
+++ b/cmake/Versioning.cmake
@@ -17,8 +17,10 @@ endif()
 option(RELEASE_COMMIT "Create a release version" OFF)
 if(RELEASE_COMMIT)
     set (LIBRARY_VERSION ${PROJECT_VERSION})
-else()
+elseif(uvgrtp_GIT_HASH)
     set (LIBRARY_VERSION ${PROJECT_VERSION} + "-" + ${uvgrtp_GIT_HASH})
+else()
+    set (LIBRARY_VERSION "")
 endif()
 
 configure_file(cmake/version.cpp.in version.cpp


### PR DESCRIPTION
If I download the ZIP file from the GitHub homepage, and try to build with -DBUILD_SHARED_LIBS=TRUE:

    curl -L -o uvgRTP-master.zip https://github.com/ultravideo/uvgRTP/archive/refs/heads/master.zip
    unzip uvgRTP-master.zip
    cd uvgRTP-master
    mkdir build ; cd build
    cmake -DBUILD_SHARED_LIBS=TRUE ..
    make

I get the following error:

    [  2%] Built target uvgrtp_version
    /Applications/Xcode.app/Contents/Developer/usr/bin/make -f CMakeFiles/uvgrtp.dir/build.make CMakeFiles/uvgrtp.dir/depend
    CMakeFiles/uvgrtp.dir/build.make:560: *** missing separator.  Stop.
    make[2]: *** [CMakeFiles/uvgrtp.dir/all] Error 2

Looking at line 560 of CMakeFiles/uvgrtp.dir/build.make, I see:

    libuvgrtp.2.0.1;+;-;+.dylib: CMakeFiles/uvgrtp.dir/src/clock.cc.o

";+;-;+" is added by this line in [cmake/Versioning.cmake](https://github.com/ultravideo/uvgRTP/blob/master/cmake/Versioning.cmake#L20):

    else()
        set (LIBRARY_VERSION ${PROJECT_VERSION} + "-" + ${uvgrtp_GIT_HASH})

because uvgrtp_GIT_HASH is not defined. So I fix that and now CMake builds these libraries:

    uvgRTP-master/build/libuvgrtp.dylib
    uvgRTP-master/build/libuvgrtp..dylib
    uvgRTP-master/build/libuvgrtp.2.dylib

So I changed CMakeLists.txt to only set the target property SOVERSION conditionally (when LIBRARY_VERSION is known).