### PR TITLE
rtcp: deepcopy APP packet data and handle it internally

### DIFF
--- a/include/uvgrtp/rtcp.hh
+++ b/include/uvgrtp/rtcp.hh
@@ -75,6 +75,10 @@ namespace uvgrtp {
     };
 
     struct rtcp_app_packet {
+        rtcp_app_packet(const rtcp_app_packet& orig_packet) = delete;
+        rtcp_app_packet(const char* name, uint8_t subtype, size_t payload_len, const uint8_t* payload);
+        ~rtcp_app_packet();
+
         const char* name;
         uint8_t subtype;
 


### PR DESCRIPTION
Currently, this function only creates a shallow copy of the name and payload, so if the original pointers are deleted it leads to undefined behavior. 
```cpp
rtp_error_t uvgrtp::rtcp::send_app_packet(const char* name, uint8_t subtype,
    size_t payload_len, const uint8_t* payload)
{
    std::string str(name);
    rtcp_app_packet packet = { name, subtype, payload_len, payload };
    packet_mutex_.lock();
    if (!app_packets_[name].empty())
    {
        LOG_WARN("Adding a new APP packet for sending when %llu packets are waiting to be sent",
            app_packets_[name].size());
    }
    app_packets_[name].push_back(packet);
    packet_mutex_.unlock();

    return RTP_OK;
}
```
My implementation handles allocation/deallocation internally. 