### PR TITLE
rtcp: add a public getter function for interval_ms_

### DIFF
--- a/include/uvgrtp/rtcp.hh
+++ b/include/uvgrtp/rtcp.hh
@@ -199,6 +199,9 @@ namespace uvgrtp {
             /* Update various session statistics */
             void update_session_statistics(const uvgrtp::frame::rtp_frame *frame);
 
+            /* Getter for interval_ms_, which is calculated by set_session_bandwidth */
+            uint32_t get_rtcp_interval_ms() const;
+
             void set_session_bandwidth(int kbps);
 
             /* Return SSRCs of all participants */

--- a/src/rtcp.cc
+++ b/src/rtcp.cc
@@ -1767,6 +1767,11 @@ rtp_error_t uvgrtp::rtcp::send_app_packet(const char* name, uint8_t subtype,
     return RTP_OK;
 }
 
+uint32_t uvgrtp::rtcp::get_rtcp_interval_ms() const 
+{
+    return interval_ms_;
+}
+
 void uvgrtp::rtcp::set_session_bandwidth(int kbps)
 {
     interval_ms_ = 1000*360 / kbps; // the reduced minimum (see section 6.2 in RFC 3550)


### PR DESCRIPTION
Currently there is no way of knowing what the interval is