### PR TITLE
rtcp: shift RR sequence cycles on wraparound

### DIFF
--- a/src/rtcp.cc
+++ b/src/rtcp.cc
@@ -915,7 +915,7 @@ void uvgrtp::rtcp::update_session_statistics(const uvgrtp::frame::rtp_frame *fra
     p->stats.received_bytes += (uint32_t)frame->payload_len;
 
     /* calculate number of dropped packets */
-    int extended_max = p->stats.cycles + p->stats.max_seq;
+    int extended_max = (static_cast<int>(p->stats.cycles) << 16) + p->stats.max_seq;
     int expected     = extended_max - p->stats.base_seq + 1;
 
     int dropped = expected - p->stats.received_pkts;


### PR DESCRIPTION
This was not shifted, thus causing the wraparound to not be added 
![image](https://user-images.githubusercontent.com/70014877/180824670-4cfce0c4-6aef-4ffa-9b28-9cc7f1ddab72.png)
