### PR TITLE
system: add compilation support for arc4random() if getrandom() isn't available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,8 +193,14 @@ if (UNIX)
     include(CheckCXXSymbolExists)
     check_cxx_symbol_exists(getrandom sys/random.h HAVE_GETRANDOM)
 
+    # Check the arc4random() function exists
+    check_cxx_symbol_exists(arc4random stdlib.h HAVE_ARC4RANDOM)
+    
     if(HAVE_GETRANDOM)
         target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_GETRANDOM=1)
+    endif()
+    if(HAVE_ARC4RANDOM)
+        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_ARC4RANDOM=1)
     endif()
 endif (UNIX)
 

--- a/src/random.cc
+++ b/src/random.cc
@@ -24,7 +24,7 @@ rtp_error_t uvgrtp::random::init()
 #ifdef _WIN32
     srand(GetTickCount());
 #else
-    srand(time(NULL));
+    srand(int(time(NULL)));
 #endif
     return RTP_OK;
 }
@@ -34,6 +34,9 @@ int uvgrtp::random::generate(void *buf, size_t n)
 #ifndef _WIN32
 #ifdef HAVE_GETRANDOM
     return getrandom(buf, n, 0);
+#elif HAVE_ARC4RANDOM
+    arc4random_buf(buf, n);
+    return 0;
 #else
 
     // Replace with the syscall
@@ -51,7 +54,7 @@ int uvgrtp::random::generate(void *buf, size_t n)
     }
 
     return read;
-#endif // HAVE_GETRANDOM
+#endif
 #else
 
     if (n > UINT32_MAX)


### PR DESCRIPTION
Detect and use arc4random() if getrandom() isn't available.  This is a PR that takes a step closer to supporting BSD-ish *nix, like macOS. 