### PR TITLE
common: Remove stray quote from include to silence warning

### DIFF
--- a/include/uvgrtp/socket.hh
+++ b/include/uvgrtp/socket.hh
@@ -40,7 +40,7 @@ namespace uvgrtp {
         }
         if (n == 0)
             return -1;
-        return n;
+        return int(n);
     }
 #endif
 

--- a/src/srtp/srtp.cc
+++ b/src/srtp/srtp.cc
@@ -1,6 +1,6 @@
 #include "srtp.hh"
 
-#include "uvgrtp/crypto.hh""
+#include "uvgrtp/crypto.hh"
 #include "uvgrtp/frame.hh"
 
 #include "../debug.hh"


### PR DESCRIPTION
common: Remove stray quote from include to silence warning