### PR TITLE
build: Added alternative search name for libcrypto++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ if (UNIX)
 
         # Find crypto++
         if(NOT DISABLE_CRYPTO)
-            pkg_search_module(CRYPTOPP libcrypto++)
+            pkg_search_module(CRYPTOPP libcrypto++ cryptopp)
             if(CRYPTOPP_FOUND)
               list(APPEND UVGRTP_CXX_FLAGS ${CRYPTOPP_CFLAGS_OTHER})
               list(APPEND UVGRTP_LINKER_FLAGS ${CRYPTOPP_LDFLAGS})


### PR DESCRIPTION
When trying to build under Fedora 36, CMake would give the following output
```
-- Checking for one of the modules 'libcrypto++'
libcrypto++ not found. Encryption will be disabled
```
Fedora OS install this package as 'cryptopp'