### PR TITLE
formats: fix a bug in SCL, sequence like \0\0\0\1\0 not detected

### DIFF
--- a/src/formats/h26x.cc
+++ b/src/formats/h26x.cc
@@ -190,7 +190,7 @@ ssize_t uvgrtp::formats::h26x::find_h26x_start_code(
         {
             /* Previous dword had zeros but this doesn't. The only way there might be a start code
              * is if the most significant byte of current dword is 0x01 */
-            if (prev_had_zero && !cur_has_zero) {
+            if (prev_had_zero) {
                 /* previous dword: 0xXX000000 or 0xXXXX0000 and current dword 0x01XXXXXX */
 #if __BYTE_ORDER == __LITTLE_ENDIAN
                 if (((cur_value32 >> 0) & 0xff) == 0x01 && ((prev_value32 >> 16) & 0xffff) == 0) {


### PR DESCRIPTION
If the input data has a zero after the start code with an offset of 1
Meaning case where basically:
(BIG_ENDIAN)
`prev_value32 = 0xXX000000;`
`cur_value32 = 0x0100XXXX;`

The current version of SCL does not find the actual start code because it's assuming no zeros in the current byte.