### PR TITLE
tests: Add unit test for H.26x start code lookup (SCL)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,9 +12,14 @@ target_sources(${PROJECT_NAME}
             test_3_rtcp.cpp
             test_4_formats.cpp
             test_5_srtp_zrtp.cpp
+            test_6_scl_unit_test.cpp
             test_common.hh
         )
 
+target_include_directories(${PROJECT_NAME}
+        PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src>
+        )
+        
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
         GTest::GTestMain

--- a/test/test_6_scl_unit_test.cpp
+++ b/test/test_6_scl_unit_test.cpp
@@ -1,0 +1,34 @@
+// Tests H26x Start Code Lookup code with different offsets
+
+#include <iostream>
+#include <cstdint>
+#include <cstring>
+
+#include "test_common.hh"
+
+#include "../src/formats/h266.hh"
+
+TEST(FormatTests, h26x_scl) {
+    uvgrtp::context ctx;
+    uvgrtp::session* local_session = ctx.create_session("127.0.0.1");
+    std::shared_ptr<uvgrtp::rtp>    rtp_;
+    auto socket_ = std::shared_ptr<uvgrtp::socket>(new uvgrtp::socket(0));
+    auto format_26x = uvgrtp::formats::h266(socket_, rtp_, 0);
+
+    for(int offset = 0; offset < 16; offset++) {
+      uint8_t data[128];
+      memset(data, 128, 128);
+
+      data[offset] = 0;
+      data[offset+1] = 0;
+      data[offset+2] = 0;
+      data[offset+3] = 1;
+      data[offset+4] = 0;
+
+      std::cout << "Testing SCL offset " << offset << std::endl;
+      uint8_t start_len;
+      size_t out = format_26x.find_h26x_start_code(data, 128-offset, 0, start_len);
+
+      EXPECT_EQ(4+offset,(int)out);
+    }
+}


### PR DESCRIPTION
This adds a unit test for uvgrtp::formats::h26x::find_h26x_start_code()
 - Current master has a bug causing the test to fail