### PR TITLE
RTP: allow custom ssrc setting

### DIFF
--- a/include/uvgrtp/rtcp.hh
+++ b/include/uvgrtp/rtcp.hh
@@ -376,6 +376,8 @@ namespace uvgrtp {
             size_t rtcp_length_in_bytes(uint16_t length);
 
             void set_payload_size(size_t mtu_size);
+
+            void set_ssrc(uint32_t ssrc);
             /// \endcond
 
         private:
@@ -512,7 +514,7 @@ namespace uvgrtp {
             bool initial_;
 
             /* Copy of our own current SSRC */
-            const uint32_t ssrc_;
+            uint32_t ssrc_;
 
             /* NTP timestamp associated with initial RTP timestamp (aka t = 0) */
             uint64_t clock_start_;

--- a/include/uvgrtp/util.hh
+++ b/include/uvgrtp/util.hh
@@ -362,6 +362,13 @@ enum RTP_CTX_CONFIGURATION_FLAGS {
      * See RCC_FPS_NUMERATOR for more info.
      */
     RCC_FPS_DENOMINATOR  = 9,
+
+    /** Set the SSRC of the stream manually
+    * 
+    * By default SSRC is generated randomly
+    */
+    RCC_SSRC = 10,
+
     /// \cond DO_NOT_DOCUMENT
     RCC_LAST
     /// \endcond

--- a/src/media_stream.cc
+++ b/src/media_stream.cc
@@ -660,7 +660,14 @@ rtp_error_t uvgrtp::media_stream::configure_ctx(int rcc_flag, ssize_t value)
             media_->set_fps(fps_numerator_, fps_denominator_);
             break;
         }           
+        case RCC_SSRC: {
+            if (value <= 0 || value > (ssize_t)UINT32_MAX)
+                return RTP_INVALID_VALUE;
 
+            rtp_-> set_ssrc(uint32_t(value));
+            rtcp_->set_ssrc(uint32_t(value));
+            break;
+        }
         default:
             return RTP_INVALID_VALUE;
     }

--- a/src/rtcp.cc
+++ b/src/rtcp.cc
@@ -1853,3 +1853,8 @@ void uvgrtp::rtcp::set_payload_size(size_t mtu_size)
 {
     mtu_size_ = mtu_size;
 }
+
+void uvgrtp::rtcp::set_ssrc(uint32_t ssrc)
+{
+    ssrc_ = ssrc;
+}

--- a/src/rtp.cc
+++ b/src/rtp.cc
@@ -199,6 +199,11 @@ void uvgrtp::rtp::set_pkt_max_delay(size_t delay)
     delay_ = delay;
 }
 
+void uvgrtp::rtp::set_ssrc(uint32_t ssrc)
+{
+    ssrc_ = ssrc;
+}
+
 size_t uvgrtp::rtp::get_pkt_max_delay() const
 {
     return delay_;

--- a/src/rtp.hh
+++ b/src/rtp.hh
@@ -33,6 +33,7 @@ namespace uvgrtp {
             void set_timestamp(uint64_t timestamp);
             void set_payload_size(size_t payload_size);
             void set_pkt_max_delay(size_t delay);
+            void set_ssrc(uint32_t ssrc);
 
             void fill_header(uint8_t *buffer);
             void update_sequence(uint8_t *buffer);


### PR DESCRIPTION
This is a rough draft of my proposal for fixing #180. This fixes the reconnecting problems described in the issue. 
The RTCP thread not exiting on the receiver side is actually not related to this at all. Might be an error in my code. 

Anyway, let me know if you want me to finish this, or if you have a better idea. I am thinking to store the stream SSRC also in the media_stream object. That way there is no need to pass custom ssrc through so many functions as a parameter. 