### PR TITLE
config: allow for custom SSRC. Added thread safety

### DIFF
--- a/include/uvgrtp/media_stream.hh
+++ b/include/uvgrtp/media_stream.hh
@@ -5,7 +5,7 @@
 #include <unordered_map>
 #include <memory>
 #include <string>
-
+#include <atomic>
 
 #ifndef _WIN32
 #include <sys/socket.h>
@@ -345,6 +345,8 @@ namespace uvgrtp {
 
             ssize_t fps_numerator_ = 30;
             ssize_t fps_denominator_ = 1;
+
+            std::shared_ptr<std::atomic<std::uint32_t>> ssrc_;
     };
 }
 

--- a/include/uvgrtp/rtcp.hh
+++ b/include/uvgrtp/rtcp.hh
@@ -12,6 +12,7 @@
 #include <memory>
 #include <mutex>
 #include <deque>
+#include <atomic>
 
 namespace uvgrtp {
 
@@ -108,8 +109,8 @@ namespace uvgrtp {
     class rtcp {
         public:
             /// \cond DO_NOT_DOCUMENT
-            rtcp(std::shared_ptr<uvgrtp::rtp> rtp, std::string cname, int rce_flags);
-            rtcp(std::shared_ptr<uvgrtp::rtp> rtp, std::string cname, std::shared_ptr<uvgrtp::srtcp> srtcp, int rce_flags);
+            rtcp(std::shared_ptr<uvgrtp::rtp> rtp, std::shared_ptr<std::atomic<std::uint32_t>> ssrc, std::string cname, int rce_flags);
+            rtcp(std::shared_ptr<uvgrtp::rtp> rtp, std::shared_ptr<std::atomic<std::uint32_t>> ssrc, std::string cname, std::shared_ptr<uvgrtp::srtcp> srtcp, int rce_flags);
             ~rtcp();
 
             /* start the RTCP runner thread
@@ -512,7 +513,7 @@ namespace uvgrtp {
             bool initial_;
 
             /* Copy of our own current SSRC */
-            const uint32_t ssrc_;
+            std::shared_ptr<std::atomic_uint> ssrc_;
 
             /* NTP timestamp associated with initial RTP timestamp (aka t = 0) */
             uint64_t clock_start_;

--- a/include/uvgrtp/util.hh
+++ b/include/uvgrtp/util.hh
@@ -362,6 +362,13 @@ enum RTP_CTX_CONFIGURATION_FLAGS {
      * See RCC_FPS_NUMERATOR for more info.
      */
     RCC_FPS_DENOMINATOR  = 9,
+
+    /** Set the SSRC of the stream manually
+    *
+    * By default SSRC is generated randomly
+    */
+    RCC_SSRC = 10,
+
     /// \cond DO_NOT_DOCUMENT
     RCC_LAST
     /// \endcond

--- a/src/rtp.cc
+++ b/src/rtp.cc
@@ -17,8 +17,8 @@
 
 #define INVALID_TS UINT64_MAX
 
-uvgrtp::rtp::rtp(rtp_format_t fmt):
-    ssrc_(uvgrtp::random::generate_32()),
+uvgrtp::rtp::rtp(rtp_format_t fmt, std::shared_ptr<std::atomic<std::uint32_t>> ssrc):
+    ssrc_(ssrc),
     ts_(uvgrtp::random::generate_32()),
     seq_(uvgrtp::random::generate_32() & 0xffff),
     fmt_(fmt),
@@ -40,7 +40,7 @@ uvgrtp::rtp::~rtp()
 
 uint32_t uvgrtp::rtp::get_ssrc() const
 {
-    return ssrc_;
+    return *ssrc_.get();
 }
 
 uint16_t uvgrtp::rtp::get_sequence() const
@@ -145,7 +145,7 @@ void uvgrtp::rtp::fill_header(uint8_t *buffer)
     buffer[1] = (payload_ & 0x7f) | (0 << 7);
 
     *(uint16_t *)&buffer[2] = htons(seq_);
-    *(uint32_t *)&buffer[8] = htonl(ssrc_);
+    *(uint32_t *)&buffer[8] = htonl(*ssrc_.get());
 
     if (timestamp_ == INVALID_TS) {
 

--- a/src/rtp.hh
+++ b/src/rtp.hh
@@ -4,6 +4,8 @@
 #include "uvgrtp/util.hh"
 
 #include <chrono>
+#include <memory>
+#include <atomic>
 
 namespace uvgrtp {
 
@@ -14,7 +16,7 @@ namespace uvgrtp {
 
     class rtp {
         public:
-            rtp(rtp_format_t fmt);
+            rtp(rtp_format_t fmt, std::shared_ptr<std::atomic<std::uint32_t>> ssrc);
             ~rtp();
 
             uint32_t     get_ssrc()          const;
@@ -44,7 +46,7 @@ namespace uvgrtp {
 
             void set_default_clock_rate(rtp_format_t fmt);
 
-            uint32_t ssrc_;
+            std::shared_ptr<std::atomic<std::uint32_t>> ssrc_;
             uint32_t ts_;
             uint16_t seq_;
             rtp_format_t fmt_;


### PR DESCRIPTION
An alternative solution for #180. Here, we share an SSRC between the objects in a thread-safe way. No intrusion on the API, as opposed to #182. 