### PR TITLE
random: Replace system random calls with STL

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -6,7 +6,6 @@
 #include "crypto.hh"
 #include "debug.hh"
 #include "hostname.hh"
-#include "random.hh"
 
 #include <cstdlib>
 #include <cstring>
@@ -45,8 +44,6 @@ uvgrtp::context::context()
     if ((rc = WSAStartup(MAKEWORD(2, 2), &wsd)) != 0)
         log_platform_error("WSAStartup() failed");
 #endif
-
-    uvgrtp::random::init();
 }
 
 uvgrtp::context::~context()

--- a/src/random.cc
+++ b/src/random.cc
@@ -1,108 +1,12 @@
 #include "random.hh"
 
-#include "debug.hh"
+#include <limits>
+#include <random>
 
-#if defined(UVGRTP_HAVE_GETRANDOM)
-#include <sys/random.h>
-#elif defined(_WIN32)
-#include <winsock2.h>
-#include <windows.h>
-#include <wincrypt.h>
-#elif defined(__APPLE__)
-#include <Security/SecRandom.h>
-#endif
+static std::mt19937 rng{std::random_device{}()};
+static std::uniform_int_distribution<uint32_t> gen32_dist{
+    std::numeric_limits<uint32_t>::min(), std::numeric_limits<uint32_t>::max()};
 
-#ifndef _WIN32
-#include <unistd.h>
-#include <sys/syscall.h>
-#endif
-
-
-#include <cstdlib>
-#include <ctime>
-
-rtp_error_t uvgrtp::random::init()
-{
-#ifdef _WIN32
-
-    uint32_t ticks = (uint32_t)GetTickCount64();
-    srand(ticks);
-#else
-    srand(time(NULL));
-#endif
-    return RTP_OK;
-}
-
-int uvgrtp::random::generate(void *buf, size_t n)
-{
-#if defined(UVGRTP_HAVE_GETRANDOM)
-
-    return getrandom(buf, n, 0);
-
-#elif defined(SYS_getrandom)
-
-    // Replace with the syscall
-    int read = syscall(SYS_getrandom, buf, n, 0);
-
-    // On error, return the same value as getrandom()
-    if (read == -EINTR || read == -ERESTART) {
-        errno = EINTR;
-        read = -1;
-    }
-
-    if (read < -1) {
-        errno = -read;
-        read = -1;
-    }
-
-    return read;
-
-#elif defined(_WIN32)
-
-    if (n > UINT32_MAX)
-    {
-        UVG_LOG_WARN("Tried to generate too large random number");
-        n = UINT32_MAX;
-    }
-
-    HCRYPTPROV hCryptProv;
-    if (CryptAcquireContext(&hCryptProv, NULL, NULL, PROV_RSA_FULL, 0) == TRUE) {
-        bool res = CryptGenRandom(hCryptProv, (DWORD)n, (BYTE *)buf);
-
-        CryptReleaseContext(hCryptProv, 0);
-
-        return res ? 0 : -1;
-    }
-
-#elif defined(__APPLE__)
-
-    int status = SecRandomCopyBytes(kSecRandomDefault, n, buf);
-    if (status == errSecSuccess)
-    {
-        return n;
-    }
-
-#endif
-
-    return -1;
-}
-
-uint32_t uvgrtp::random::generate_32()
-{
-    uint32_t value;
-
-    if (uvgrtp::random::generate(&value, sizeof(uint32_t)) < 0)
-        return rand();
-
-    return value;
-}
-
-uint64_t uvgrtp::random::generate_64()
-{
-    uint64_t value;
-
-    if (uvgrtp::random::generate(&value, sizeof(uint64_t)) < 0)
-        return rand();
-
-    return value;
+uint32_t uvgrtp::random::generate_32() {
+    return gen32_dist(rng);
 }

--- a/src/random.hh
+++ b/src/random.hh
@@ -1,22 +1,9 @@
-
-#include "uvgrtp/util.hh"
-
 #include <cstdint>
-#include <stddef.h>
 
 namespace uvgrtp {
     namespace random {
-
-        /* Initialize the PSRNG of standard lib and for windows
-         * acquire the cryptographic context
-         *
-         * Return RTP_OK on success
-         * Return RTP_GENERIC_ERROR if acquiring the the crypt context fails */
-        rtp_error_t init();
-
-        int generate(void *buf, size_t n);
+        /* Generate random unsigned 32 bit integer */
         uint32_t generate_32();
-        uint64_t generate_64();
     }
 }
 


### PR DESCRIPTION
I hit a deadlock when generate() was calling `syscall(SYS_getrandom, buf, n, 0)` on an embedded system. I went with a standard solution, which cut down on some code and should be more portable. I also removed the apparently unused `generate_64()` function. If that function is truly needed, I can update to include it.

Tested with gcc on linux, unable to test on windows.