### PR TITLE
common: Added multicast bind support for ipv4 and ipv6

### DIFF
--- a/src/socket.cc
+++ b/src/socket.cc
@@ -134,6 +134,18 @@ rtp_error_t uvgrtp::socket::bind(sockaddr_in& local_address)
         }
     } else {
         // Multicast address
+        // Reuse address to enabled receiving the same stream multiple times
+        const int enable = 1;
+        if (::setsockopt(socket_, SOL_SOCKET, SO_REUSEADDR, (const char*)&enable, sizeof(int)) < 0) {
+#ifdef _WIN32
+            win_get_last_error();
+#else
+            fprintf(stderr, "%s\n", strerror(errno));
+#endif
+
+            UVG_LOG_ERROR("Reuse address failed!");
+        }
+
         // Bind with empty address
         auto bind_addr_in = local_address_;
         bind_addr_in.sin_addr.s_addr = htonl(INADDR_ANY);
@@ -191,6 +203,18 @@ rtp_error_t uvgrtp::socket::bind_ip6(sockaddr_in6& local_address)
         }
     } else {
         // Multicast address
+        // Reuse address to enabled receiving the same stream multiple times
+        const int enable = 1;
+        if (::setsockopt(socket_, SOL_SOCKET, SO_REUSEADDR, (const char*)&enable, sizeof(int)) < 0) {
+#ifdef _WIN32
+            win_get_last_error();
+#else
+            fprintf(stderr, "%s\n", strerror(errno));
+#endif
+
+            UVG_LOG_ERROR("Reuse address failed!");
+        }
+
         // Bind with empty address
         auto bind_addr_in = local_ip6_address_;
         bind_addr_in.sin6_addr = in6addr_any;

--- a/test/test_2_rtp.cpp
+++ b/test/test_2_rtp.cpp
@@ -8,6 +8,7 @@
 constexpr uint16_t SEND_PORT = 9300;
 
 constexpr char REMOTE_ADDRESS[] = "127.0.0.1";
+constexpr char MULTICAST_ADDRESS[] = "224.0.0.122";
 constexpr uint16_t RECEIVE_PORT = 9302;
 
 void rtp_receive_hook(void* arg, uvgrtp::frame::rtp_frame* frame);
@@ -380,6 +381,36 @@ TEST(RTPTests, send_large_amounts)
     test_frame = std::unique_ptr<uint8_t[]>(new uint8_t[frame_size]);
     memset(test_frame.get(), 'b', frame_size);
     send_packets(std::move(test_frame), frame_size, sess, sender, test_packets, 0, true, RTP_NO_FLAGS);
+
+    cleanup_ms(sess, sender);
+    cleanup_ms(sess, receiver);
+    cleanup_sess(ctx, sess);
+}
+
+TEST(RTPTests, rtp_multicast)
+{
+    // Tests with a multicast address
+    std::cout << "Starting RTP multicast test" << std::endl;
+    uvgrtp::context ctx;
+    uvgrtp::session* sess = ctx.create_session(MULTICAST_ADDRESS, MULTICAST_ADDRESS);
+
+    uvgrtp::media_stream* sender = nullptr;
+    uvgrtp::media_stream* receiver = nullptr;
+
+    int flags = RCE_FRAGMENT_GENERIC;
+    if (sess)
+    {
+        sender = sess->create_stream(RECEIVE_PORT, SEND_PORT, RTP_FORMAT_GENERIC, flags);
+        receiver = sess->create_stream(SEND_PORT, RECEIVE_PORT, RTP_FORMAT_GENERIC, flags);
+    }
+
+    int test_packets = 10;
+    std::vector<size_t> sizes = { 1000, 2000 };
+    for (size_t& size : sizes)
+    {
+        std::unique_ptr<uint8_t[]> test_frame = create_test_packet(RTP_FORMAT_GENERIC, 0, false, size, RTP_NO_FLAGS);
+        test_packet_size(std::move(test_frame), test_packets, size, sess, sender, receiver, RTP_NO_FLAGS);
+    }
 
     cleanup_ms(sess, sender);
     cleanup_ms(sess, receiver);

--- a/test/test_7_ipv6.cpp
+++ b/test/test_7_ipv6.cpp
@@ -9,7 +9,7 @@ constexpr uint16_t SEND_PORT = 9300;
 constexpr char REMOTE_ADDRESS[] = "::1";
 constexpr uint16_t RECEIVE_PORT = 9400;
 
-constexpr char MULTICAST_INTERFACE[] = "FF02:0:0:0:0:0:0:0";
+constexpr char MULTICAST_ADDRESS[] = "FF02:0:0:0:0:0:0:0";
 
 // RTCP TEST PARAMETERS
 constexpr uint16_t PAYLOAD_LEN = 256;
@@ -537,7 +537,7 @@ TEST(RTPTests_ip6, rtp_multicast_ip6)
     // Tests installing a hook to uvgRTP
     std::cout << "Starting IPv6 RTP hook test" << std::endl;
     uvgrtp::context ctx;
-    uvgrtp::session* sess = ctx.create_session(MULTICAST_INTERFACE, MULTICAST_INTERFACE);
+    uvgrtp::session* sess = ctx.create_session(MULTICAST_ADDRESS, MULTICAST_ADDRESS);
 
     uvgrtp::media_stream* sender = nullptr;
     uvgrtp::media_stream* receiver = nullptr;
@@ -559,5 +559,36 @@ TEST(RTPTests_ip6, rtp_multicast_ip6)
 
     cleanup_ms(sess, sender);
     cleanup_ms(sess, receiver);
+    cleanup_sess(ctx, sess);
+}
+
+TEST(RTPTests_ip6, rtp_multicast_multiple_ip6)
+{
+    // Tests with a multicast address
+    std::cout << "Starting RTP multicast test" << std::endl;
+    uvgrtp::context ctx;
+    uvgrtp::session* sess = ctx.create_session(MULTICAST_ADDRESS, MULTICAST_ADDRESS);
+
+    EXPECT_NE(nullptr, sess);
+    if (!sess) return;
+
+    int flags = RCE_FRAGMENT_GENERIC;
+
+    auto sender = sess->create_stream(RECEIVE_PORT, SEND_PORT, RTP_FORMAT_GENERIC, flags);
+    std::vector<uvgrtp::media_stream*> receivers = {
+        sess->create_stream(SEND_PORT, RECEIVE_PORT, RTP_FORMAT_GENERIC, flags),
+        sess->create_stream(SEND_PORT, RECEIVE_PORT, RTP_FORMAT_GENERIC, flags)
+    };
+
+    int test_packets = 10;
+    std::vector<size_t> sizes = { 1000, 2000 };
+    for (size_t& size : sizes)
+    {
+        std::unique_ptr<uint8_t[]> test_frame = create_test_packet(RTP_FORMAT_GENERIC, 0, false, size, RTP_NO_FLAGS);
+        test_packet_size(std::move(test_frame), test_packets, size, sess, sender, receivers, RTP_NO_FLAGS);
+    }
+
+    cleanup_ms(sess, sender);
+    for (auto receiver : receivers) cleanup_ms(sess, receiver);
     cleanup_sess(ctx, sess);
 }


### PR DESCRIPTION
Added multicast address detection in `uvgrtp::socket::bind` `uvgrtp::socket::bind_ip6`
Tests added to test_2_rtp and test_7_ipv6
Tested on:
- Windows 10 with MSVC
- Ubuntu 20.04.6 LTS Linux aarch64 with gcc
