### PR TITLE
Fix build with gcc13

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -1,9 +1,9 @@
-if (NOT UVGRTP_DISABLE_TESTS)
-    # PThread
-    set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-    set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-    find_package( Threads REQUIRED )
+# PThread
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package( Threads REQUIRED )
 
+if (NOT UVGRTP_DISABLE_TESTS)
     # Git
     find_package(Git)
 

--- a/include/uvgrtp/media_stream.hh
+++ b/include/uvgrtp/media_stream.hh
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <atomic>
+#include <cstdint>
 
 #ifndef _WIN32
 #include <sys/socket.h>

--- a/src/crypto.hh
+++ b/src/crypto.hh
@@ -43,6 +43,7 @@
 #endif // __cplusplus
 
 #include <iostream>
+#include <cstdint>
 
 namespace uvgrtp {
 


### PR DESCRIPTION
When building with gcc 13, cstdint have to be included in some additional files. 
Furthermore, if the Tests are excluded, the Threads::Threads cmake target isn't found (the find_package call will be excluded then, too). Therefore I've changed it so it will get always found