### PR TITLE
Update h26x.cc - fixed initialization order of 'dropped_ts_' and 'opped_in_order_'

### DIFF
--- a/src/formats/h26x.cc
+++ b/src/formats/h26x.cc
@@ -104,8 +104,8 @@ uvgrtp::formats::h26x::h26x(std::shared_ptr<uvgrtp::socket> socket, std::shared_
     received_frames_(),
     received_info_(),
     fragments_(),
-    dropped_in_order_(),
     dropped_ts_(),
+    dropped_in_order_(),
     rtp_ctx_(rtp),
     last_garbage_collection_(uvgrtp::clock::hrc::now()),
     discard_until_key_frame_(true)


### PR DESCRIPTION
Hi! I'm trying to use `uvgRTP` "directly":

```cmake
cmake_minimum_required(VERSION 3.5)

project(my_project LANGUAGES CXX)

set(CMAKE_CXX_STANDARD 11)
set(CMAKE_CXX_STANDARD_REQUIRED ON)

add_executable(my_project main.cpp)

# ------------------------------------------------------------------------------
# uvgRTP library

set(UVGRTP_DISABLE_CRYPTO       ON CACHE BOOL "" FORCE)
set(UVGRTP_DISABLE_PRINTS      OFF CACHE BOOL "" FORCE)
set(UVGRTP_DISABLE_WERROR      OFF CACHE BOOL "" FORCE)

set(UVGRTP_DISABLE_TESTS        ON CACHE BOOL "" FORCE)
set(UVGRTP_DISABLE_EXAMPLES     ON CACHE BOOL "" FORCE)
set(UVGRTP_DISABLE_INSTALL      ON CACHE BOOL "" FORCE)

set(UVGRTP_DOWNLOAD_CRYPTO     OFF CACHE BOOL "" FORCE)

set(UVGRTP_RELEASE_COMMIT      OFF CACHE BOOL "" FORCE)

# obsolete, do not use
set(DISABLE_CRYPTO      OFF CACHE BOOL "" FORCE)
set(DISABLE_PRINTS      OFF CACHE BOOL "" FORCE)
set(DISABLE_WERROR      OFF CACHE BOOL "" FORCE)

add_subdirectory(
    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/uvgRTP/uvgRTP-master/
    my_project_uvgrtp
    EXCLUDE_FROM_ALL
)

# ------------------------------------------------------------------------------

target_link_libraries(my_project
    PRIVATE
        uvgrtp
)

# ------------------------------------------------------------------------------

include(GNUInstallDirs)
install(TARGETS my_project
    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
)
```

GCC version: `gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0`

Content of `main.cpp` is [examples/sending_generic.cc](https://github.com/ultravideo/uvgRTP/blob/master/examples/sending_generic.cc)

----

It failed to build with the next compilation errors:

```bash
/path/to/uvgRTP-master/src/formats/h26x.hh: In constructor ‘uvgrtp::formats::h26x::h26x(std::shared_ptr<uvgrtp::socket>, std::shared_ptr<uvgrtp::rtp>, int)’:
/path/to/uvgRTP-master/src/formats/h26x.hh:202:32: error: ‘uvgrtp::formats::h26x::dropped_in_order_’ will be initialized after [-Werror=reorder]
  202 |             std::set<uint32_t> dropped_in_order_;
      |                                ^~~~~~~~~~~~~~~~~
/path/to/uvgRTP-master/src/formats/h26x.hh:199:69: error:   ‘std::unordered_map<unsigned int, std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > > > uvgrtp::formats::h26x::dropped_ts_’ [-Werror=reorder]
  199 |             std::unordered_map<uint32_t, uvgrtp::clock::hrc::hrc_t> dropped_ts_;
      |                                                                     ^~~~~~~~~~~
/path/to/uvgRTP-master/src/formats/h26x.cc:100:1: error:   when initialized here [-Werror=reorder]
  100 | uvgrtp::formats::h26x::h26x(std::shared_ptr<uvgrtp::socket> socket, std::shared_ptr<uvgrtp::rtp> rtp, int rce_flags) :
      | ^~~~~~
```

This small PR fixes it. After changing order in `srt/formats/h265.cc` everything built successfuly :)