### PR TITLE
Fixed the issue when reconstructing h264 frames that are not continuous

### DIFF
--- a/src/formats/h26x.cc
+++ b/src/formats/h26x.cc
@@ -806,10 +806,11 @@ rtp_error_t uvgrtp::formats::h26x::packet_handler(void* args, int rce_flags, uin
 
         if (s) {
             start = c;
+            continuous = true;
             reconstructed_fragments[c] = {}; // If this is start FU, initialize a new map for it
         }
 
-        if (next == c || s) {
+        if (continuous && (next == c || s)) {
             if (reconstructed_fragments.find(start) != reconstructed_fragments.end() ) {
                 continuous = true;
                 reconstructed_fragments.at(start).seqs.insert(c);

--- a/src/formats/h26x.cc
+++ b/src/formats/h26x.cc
@@ -814,6 +814,8 @@ rtp_error_t uvgrtp::formats::h26x::packet_handler(void* args, int rce_flags, uin
                 continuous = true;
                 reconstructed_fragments.at(start).seqs.insert(c);
             }
+        } else {
+            continuous = false;
         }
         next = next_seq_num(c);
         //UVG_LOG_DEBUG("Current fragment %u, next %u, start %d, end %d, continuous %d", c, next, s, e, continuous);


### PR DESCRIPTION
Hello, I noticed that there is an issue with RTP frame handling (h264), when receiving a stream with a noticeable packet loss. The crash happens in the following case. Consider the client receiving these RTP frames:
```
Packet seq 100, type = FT_START
Packet seq 101, type = FT_MIDDLE
Packet seq 102, type = FT_END // This packet lost
Packet seq 103, type = FT_START // Reconstructed (deallocated)
Packet seq 104, type = FT_END  // Reconstructed (deallocated)
Packet seq 105, type = FT_START
Packet seq 106, type = FT_END
```
In that case the packet seq 102 was lost. When the library receives seq 104, then it can successfully reconstruct the NAL unit from seq 103, 104 and deallocate them. Then the library receives seq 106 and incorrectly determines the frames 100-106 as continuous and attempts to reconstruct the NAL unit from them -> resulting in a crash when accessing deallocated 103 frame.
Looks like the issue is that `continuous` flag was never reset to false in case the frames are not continuous.
![Screenshot 2024-06-03 at 10 24 15](https://github.com/ultravideo/uvgRTP/assets/17294609/52817a48-c9e8-4b62-8bc0-6d0e49545633)

**Example of the crash:**
![Screenshot 2024-06-03 at 10 22 39](https://github.com/ultravideo/uvgRTP/assets/17294609/3b84a896-6ace-4b0b-8ab1-98bc6813ccdf)
