### PR TITLE
Fix RTCP SR RTP timestamp value calculation

### DIFF
--- a/src/rtp.cc
+++ b/src/rtp.cc
@@ -167,6 +167,7 @@ void uvgrtp::rtp::fill_header(uint8_t *buffer, bool use_old_ts)
         }
         else {
             *(uint32_t*)&buffer[4] = htonl((u_long)timestamp_);
+            rtp_ts_ = timestamp_;
         }
     }
     else if (timestamp_ == INVALID_TS) {
@@ -186,6 +187,7 @@ void uvgrtp::rtp::fill_header(uint8_t *buffer, bool use_old_ts)
     }
     else {
         *(uint32_t *)&buffer[4] = htonl((u_long)timestamp_);
+        rtp_ts_ = timestamp_;
     }
 }
 


### PR DESCRIPTION
RTCP SR (and potentially other code) uses rtp::get_rtp_ts() to calculate the RTP SR timestamp value. If push_frame is used with explicit NTP timestamp, get_rtp_ts() always returnes 0 because the member variable rtp::rtp_ts_ is never assigned. This commit adds the missing assignments.