### PR TITLE
Send pace support improved

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,12 +107,14 @@ stream->configure_ctx(RCC_PKT_MAX_DELAY, 150);
 | RCC_DYN_PAYLOAD_TYPE | Override uvgRTP's default payload number used in RTP headers | Format-specific, see [util.hh](/include/uvgrtp/util.hh) | Both |
 | RCC_CLOCK_RATE       | Override uvgRTP's default clock rate used to calculate RTP timestamps | Format-specific, see [RFC 3551](https://www.rfc-editor.org/rfc/rfc3551#section-6) | Sender |
 | RCC_MTU_SIZE         | Set the Maximum Transmission Unit (MTU) value. uvgRTP assumes the presence of UDP header (8 bytes) and IP header (20 bytes for IPv4). Those are substracted those from the given value. | 1492 bytes | Both |
-| RCC_FPS_NUMERATOR   | Set the fps used with RCE_FRAMERATE and RCE_FRAGMENT_PACING. | 30 | Sender |
+| RCC_FPS_NUMERATOR    | Set the fps used with RCE_FRAMERATE and RCE_PACE_FRAGMENT_SENDING. | 30 | Sender |
 | RCC_FPS_DENOMINATOR  | Use this in combination with RCC_FPS_NUMERATOR if you need fractional fps values. | 1 | Sender |
 | RCC_POLL_TIMEOUT     | Set the timeout value for polling the socket. | 100 ms | Receiver|
 | RCC_SSRC             | Set the SSSRC value for this media stream. | random uint32 | Sender|
 | RCC_REMOTE_SSRC      | Set the remote SSRC value that this media stream should receive packets from. | random uint32 | Receiver|
 | RCC_MULTICAST_TTL    | Set the sender packets IP TTL (Time to Live) for multicast. Must be in range [1, 255]. | system default | Sender |
+| RCC_PACE_NUMERATOR   | Set the pace rate used with RCE_PACE_FRAGMENT_SENDING. | 8 | Sender |
+| RCC_PACE_DENOMINATOR | Use this in combination with RCC_PACE_NUMERATOR. Must be higher than RCC_PACE_NUMERATOR. | 10 | Sender |
 
 ### RTP frame flags
 

--- a/include/uvgrtp/media_stream.hh
+++ b/include/uvgrtp/media_stream.hh
@@ -455,6 +455,8 @@ namespace uvgrtp {
 
             ssize_t fps_numerator_ = 30;
             ssize_t fps_denominator_ = 1;
+            ssize_t pace_numerator_ = 8;
+            ssize_t pace_denominator_ = 10;
             uint32_t bandwidth_ = 0;
             std::shared_ptr<std::atomic<std::uint32_t>> ssrc_;
             std::shared_ptr<std::atomic<std::uint32_t>> remote_ssrc_;

--- a/include/uvgrtp/util.hh
+++ b/include/uvgrtp/util.hh
@@ -395,6 +395,22 @@ enum RTP_CTX_CONFIGURATION_FLAGS {
      */
     RCC_MULTICAST_TTL = 15,
 
+    /** Set the numerator of pace rate used by uvgRTP.
+    *
+    * Default is 8.
+    *
+    * Used to compute the pace rate used when RCE_PACE_FRAGMENT_SENDING is enabled
+    */
+    RCC_PACE_NUMERATOR  = 16,
+
+    /** Set the denominator of pace rate used by uvgRTP.
+    *
+    * Default is 10.
+    *
+    * Used to compute the pace rate used when RCE_PACE_FRAGMENT_SENDING is enabled
+    */
+    RCC_PACE_DENOMINATOR  = 17,
+
     /// \cond DO_NOT_DOCUMENT
     RCC_LAST
     /// \endcond

--- a/src/formats/media.cc
+++ b/src/formats/media.cc
@@ -196,3 +196,8 @@ void uvgrtp::formats::media::set_fps(ssize_t numerator, ssize_t denominator)
 {
     fqueue_->set_fps(numerator, denominator);
 }
+
+void uvgrtp::formats::media::set_pace(ssize_t numerator, ssize_t denominator)
+{
+    fqueue_->set_pace(numerator, denominator);
+}

--- a/src/formats/media.hh
+++ b/src/formats/media.hh
@@ -72,7 +72,8 @@ namespace uvgrtp {
                 /* Return pointer to the internal frame info structure which is relayed to packet handler */
                 media_frame_info_t *get_media_frame_info();
 
-                void set_fps(ssize_t enumarator, ssize_t denominator);
+                void set_fps(ssize_t numerator, ssize_t denominator);
+                void set_pace(ssize_t numerator, ssize_t denominator);
 
             protected:
                 virtual rtp_error_t push_media_frame(sockaddr_in& addr, sockaddr_in6& addr6, uint8_t *data, size_t data_len, int rtp_flags, uint32_t ssrc);

--- a/src/frame_queue.cc
+++ b/src/frame_queue.cc
@@ -345,7 +345,7 @@ rtp_error_t uvgrtp::frame_queue::flush_queue(sockaddr_in& addr, sockaddr_in6& ad
     if ((rce_flags_ & RCE_PACE_FRAGMENT_SENDING) && fps_ && !force_sync_)
     {
         // allocate 80% of frame interval for pacing, rest for other processing
-        std::chrono::nanoseconds packet_interval = 8*frame_interval_/(10*active_->packets.size());
+        std::chrono::nanoseconds packet_interval = pace_numerator_*frame_interval_/(pace_denominator_*active_->packets.size());
 
         for (size_t i = 0; i < active_->packets.size(); ++i)
         {

--- a/src/frame_queue.hh
+++ b/src/frame_queue.hh
@@ -155,7 +155,13 @@ namespace uvgrtp {
                     frame_interval_ = std::chrono::nanoseconds(uint64_t(1.0 / double(numerator / denominator) * 1000*1000*1000));
                 }
                 frames_since_sync_ = 0; 
-                force_sync_ = true;
+                force_sync_ = rce_flags_ & RCE_FRAME_RATE;
+            }
+
+            void set_pace(ssize_t numerator, ssize_t denominator)
+            {
+                pace_numerator_ = numerator;
+                pace_denominator_ = denominator;
             }
 
         private:
@@ -182,6 +188,8 @@ namespace uvgrtp {
 
             bool fps_ = false;
             std::chrono::nanoseconds frame_interval_;
+            ssize_t pace_numerator_;
+            ssize_t pace_denominator_;
 
             std::chrono::high_resolution_clock::time_point fps_sync_point_;
             uint64_t frames_since_sync_ = 0;


### PR DESCRIPTION
- Added pacing rate configuration parameters

In a slow FPS use case (5ps) but with several high resolutions video streams, pacing is needed to avoid frame drops on the receiver.
Pacing will send a frame over 160ms which takes too long, ability to configure it is needed here.

- Enable pacing even when RCE_FRAME_RATE is not enabled

When the application is providing the frame rate (camera source here), we do not want uvgRTP to provide it, but we still need pacing.
By only settings the force_sync_ flag when using RCE_FRAME_RATE, the pacing can happen.
