### PR TITLE
Fixed zrtp class init order and double init warnings on g++-14

### DIFF
--- a/src/zrtp.cc
+++ b/src/zrtp.cc
@@ -36,16 +36,16 @@ uvgrtp::zrtp::zrtp():
     remote_addr_(),
     remote_ip6_addr_(),
     hello_(nullptr),
+    hello_len_(0),
     hello_ack_(nullptr),
     commit_(nullptr),
+    commit_len_(0),
     dh1_(nullptr),
     dh2_(nullptr),
+    dh_len_(0),
     conf1_(nullptr),
     conf2_(nullptr),
     confack_(nullptr),
-    hello_len_(0),
-    commit_len_(0),
-    dh_len_(0),
     zrtp_busy_(false)
 {
     cctx_.sha256 = new uvgrtp::crypto::sha256;

--- a/src/zrtp.hh
+++ b/src/zrtp.hh
@@ -201,7 +201,7 @@ namespace uvgrtp {
 
             /* Has the ZRTP connection been initialized using DH */
             bool initialized_;
-            bool dh_finished_ = false;
+            bool dh_finished_;
 
             std::shared_ptr<uvgrtp::socket> local_socket_;
             sockaddr_in remote_addr_;


### PR DESCRIPTION
Fixed gcc-14 warnings about zrtp constructor field init order to match the declaration order

Also removed the double initialization of the dh_finished_ field
