### PR TITLE
Added SO_REUSEPORT socket option on top of SO_REUSEADDR when available

### DIFF
--- a/src/socket.cc
+++ b/src/socket.cc
@@ -147,6 +147,18 @@ rtp_error_t uvgrtp::socket::bind(sockaddr_in& local_address)
             UVG_LOG_ERROR("Reuse address failed!");
         }
 
+#ifdef SO_REUSEPORT
+        // Reuse port to enabled receiving the same stream multiple times
+        if (::setsockopt(socket_, SOL_SOCKET, SO_REUSEPORT, (const char*)&enable, sizeof(int)) < 0) {
+#ifdef _WIN32
+            win_get_last_error();
+#else
+            fprintf(stderr, "%s\n", strerror(errno));
+#endif
+            UVG_LOG_ERROR("Reuse port failed!");
+        }
+#endif
+
         // Bind with empty address
         auto bind_addr_in = local_address_;
         bind_addr_in.sin_addr.s_addr = htonl(INADDR_ANY);
@@ -215,6 +227,18 @@ rtp_error_t uvgrtp::socket::bind_ip6(sockaddr_in6& local_address)
 
             UVG_LOG_ERROR("Reuse address failed!");
         }
+
+#ifdef SO_REUSEPORT
+        // Reuse port to enabled receiving the same stream multiple times
+        if (::setsockopt(socket_, SOL_SOCKET, SO_REUSEPORT, (const char*)&enable, sizeof(int)) < 0) {
+#ifdef _WIN32
+            win_get_last_error();
+#else
+            fprintf(stderr, "%s\n", strerror(errno));
+#endif
+            UVG_LOG_ERROR("Reuse port failed!");
+        }
+#endif
 
         // Bind with empty address
         auto bind_addr_in = local_ip6_address_;


### PR DESCRIPTION
Linux Kernel 3.9 added a SO_REUSEPORT socket option, that must be used with SO_REUSEADDR in order to open the same socket multiple times.

Practical case :
- Send and RTP broadcast stream with both source and destination port set to 20000
- Open this stream locally

Without this option opening the socket on the receiving app will fail
Tested on Ubuntu 24.04
